### PR TITLE
perf(search): cache continuation correction table

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -25,9 +25,9 @@ use crate::types::{
 };
 
 use super::history::{
-    CORRECTION_HISTORY_LIMIT, HistoryCell, HistoryTables, LOW_PLY_HISTORY_SIZE,
-    continuation_history_bonus_with_offset, continuation_history_weight, low_ply_history_bonus,
-    pawn_history_bonus, stat_bonus, stat_malus,
+    CORRECTION_HISTORY_LIMIT, CorrectionPieceToHistory, HistoryCell, HistoryTables,
+    LOW_PLY_HISTORY_SIZE, continuation_history_bonus_with_offset, continuation_history_weight,
+    low_ply_history_bonus, pawn_history_bonus, stat_bonus, stat_malus,
 };
 use super::movepicker::piece_value;
 use super::types::{
@@ -672,6 +672,9 @@ pub struct SearchWorker {
     /// ContinuationHistoryのsentinel
     pub cont_history_sentinel: NonNull<PieceToHistory>,
 
+    /// ContinuationCorrectionHistoryのsentinel
+    pub cont_correction_sentinel: NonNull<CorrectionPieceToHistory>,
+
     /// 全合法手生成フラグ
     pub generate_all_legal_moves: bool,
 
@@ -746,9 +749,12 @@ impl SearchWorker {
         let history = HistoryCell::new_boxed();
         // HistoryCell経由でsentinelポインタを取得
         // SAFETY: 初期化時のみ使用、他の参照と同時保持しない
-        let cont_history_sentinel = {
+        let (cont_history_sentinel, cont_correction_sentinel) = {
             let h = unsafe { history.as_ref_unchecked() };
-            NonNull::from(h.continuation_history[0][0].get_table(Piece::NONE, Square::SQ_11))
+            (
+                NonNull::from(h.continuation_history[0][0].get_table(Piece::NONE, Square::SQ_11)),
+                NonNull::from(h.correction_history.continuation_table(Piece::NONE, Square::SQ_11)),
+            )
         };
 
         let reductions = build_reductions(search_tune_params.lmr_table_coeff);
@@ -757,6 +763,7 @@ impl SearchWorker {
             eval_hash,
             history,
             cont_history_sentinel,
+            cont_correction_sentinel,
             generate_all_legal_moves: false,
             max_moves_to_draw,
             thread_id,
@@ -879,8 +886,10 @@ impl SearchWorker {
 
     fn reset_cont_history_ptrs(&mut self) {
         let sentinel = self.cont_history_sentinel;
+        let correction_sentinel = self.cont_correction_sentinel;
         for stack in self.state.stack.iter_mut() {
             stack.cont_history_ptr = sentinel;
+            stack.cont_correction_ptr = correction_sentinel;
         }
     }
 
@@ -897,11 +906,17 @@ impl SearchWorker {
         let in_check_idx = in_check as usize;
         let capture_idx = capture as usize;
         // SAFETY: 単一スレッド内で使用、可変参照と同時保持しない
-        let table = {
+        let (table, correction_table) = {
             let h = unsafe { self.history.as_ref_unchecked() };
-            NonNull::from(h.continuation_history[in_check_idx][capture_idx].get_table(piece, to))
+            (
+                NonNull::from(
+                    h.continuation_history[in_check_idx][capture_idx].get_table(piece, to),
+                ),
+                NonNull::from(h.correction_history.continuation_table(piece, to)),
+            )
         };
         self.state.stack[ply as usize].cont_history_ptr = table;
+        self.state.stack[ply as usize].cont_correction_ptr = correction_table;
         self.state.stack[ply as usize].cont_hist_key =
             Some(ContHistKey::new(in_check, capture, piece, to));
     }
@@ -909,6 +924,7 @@ impl SearchWorker {
     #[inline]
     pub(super) fn clear_cont_history_for_null(&mut self, ply: i32) {
         self.state.stack[ply as usize].cont_history_ptr = self.cont_history_sentinel;
+        self.state.stack[ply as usize].cont_correction_ptr = self.cont_correction_sentinel;
         self.state.stack[ply as usize].cont_hist_key = Some(ContHistKey::null_sentinel());
     }
 
@@ -1158,6 +1174,7 @@ impl SearchWorker {
         self.state.set_previous_pv(&self.state.root_moves[0].pv.clone());
         self.state.set_root_follow_pv();
         self.state.stack[0].cont_history_ptr = self.cont_history_sentinel;
+        self.state.stack[0].cont_correction_ptr = self.cont_correction_sentinel;
         self.state.stack[0].cont_hist_key = None;
         // ss->statScore = 0
         self.state.stack[0].stat_score = 0;
@@ -1882,6 +1899,7 @@ impl SearchWorker {
         self.state.set_previous_pv(&previous_pv);
         self.state.set_root_follow_pv();
         self.state.stack[0].cont_history_ptr = self.cont_history_sentinel;
+        self.state.stack[0].cont_correction_ptr = self.cont_correction_sentinel;
         self.state.stack[0].cont_hist_key = None;
         // root探索開始時の初期化
         self.state.stack[0].stat_score = 0;
@@ -3963,10 +3981,10 @@ impl SearchWorker {
 
 // SAFETY: SearchWorkerは単一スレッドで使用される前提。
 //
-// 1. `cont_history_ptr: NonNull<PieceToHistory>`（StackArray内の各Stack）:
-//    `self.history.continuation_history` 内のテーブルへの参照である。
-//    SearchWorkerがスレッド間でmoveされても、history フィールドも一緒にmoveされるため、
-//    ポインタの参照先は常に有効であり、データ競合も発生しない。
+// 1. `cont_history_ptr` / `cont_correction_ptr`（StackArray内の各Stack）:
+//    `self.history`が所有するcontinuation history / correction history内のテーブルへの参照である。
+//    HistoryCell本体はBox allocation内にあり、SearchWorkerがスレッド間でmoveされても再配置されない。
+//    ワーカーは移動先の単一スレッドだけで使用するため、データ競合も発生しない。
 //
 // 2. `network_ptr: *const NNUENetwork`（SearchState、layerstack-arch feature時のみ）:
 //    グローバル NETWORK (RwLock<Option<Arc<NNUENetwork>>>) 内の Arc が指す

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -5,12 +5,12 @@
 #[cfg(not(feature = "search-no-pass-rules"))]
 use crate::eval::evaluate_pass_rights;
 use crate::position::Position;
-use crate::types::{Bound, Color, DEPTH_UNSEARCHED, Depth, MAX_PLY, Move, Value};
+use crate::types::{Bound, Color, DEPTH_UNSEARCHED, Depth, MAX_PLY, Move, Piece, Square, Value};
 
 use super::alpha_beta::{
     EvalContext, ProbeOutcome, SearchContext, SearchState, TTContext, to_corrected_static_eval,
 };
-use super::history::CORRECTION_HISTORY_SIZE;
+use super::history::{CORRECTION_HISTORY_SIZE, CorrectionHistory};
 #[cfg(feature = "use-lazy-evaluate")]
 use super::search_helpers::ensure_nnue_accumulator;
 use super::search_helpers::nnue_evaluate;
@@ -28,7 +28,9 @@ use super::types::{ContHistKey, NodeType, value_from_tt};
 // =============================================================================
 
 /// 補正履歴から静的評価の補正値を算出
-#[inline]
+// production baselineと同じout-of-line形を保ち、簡略化した大規模history参照が
+// qsearchの特殊化ごとに複製されるのを防ぐ。
+#[inline(never)]
 pub(super) fn correction_value(
     st: &SearchState,
     ctx: &SearchContext<'_>,
@@ -51,38 +53,6 @@ pub(super) fn correction_value(
     };
     let move_ok = prev_move.is_normal();
 
-    // continuation correction 用キー: (ss-2) と (ss-4) の2段階
-    // cont_hist_key が未設定(None)でも sentinel にフォールバックして参照する。
-    let sentinel_key = ContHistKey::null_sentinel();
-    let cont_key_2 = if move_ok {
-        if ply >= 2 {
-            debug_assert!(((ply - 2) as usize) < st.stack.len());
-            // SAFETY: ply >= 2 かつ ply <= MAX_PLY なので (ply-2) は StackArray の範囲内。
-            match unsafe { st.stack.get_unchecked((ply - 2) as usize) }.cont_hist_key {
-                Some(key) => key,
-                None => sentinel_key,
-            }
-        } else {
-            sentinel_key
-        }
-    } else {
-        sentinel_key
-    };
-    let cont_key_4 = if move_ok {
-        if ply >= 4 {
-            debug_assert!(((ply - 4) as usize) < st.stack.len());
-            // SAFETY: ply >= 4 かつ ply <= MAX_PLY なので (ply-4) は StackArray の範囲内。
-            match unsafe { st.stack.get_unchecked((ply - 4) as usize) }.cont_hist_key {
-                Some(key) => key,
-                None => sentinel_key,
-            }
-        } else {
-            sentinel_key
-        }
-    } else {
-        sentinel_key
-    };
-
     // SAFETY: 単一スレッド内で使用、可変参照と同時保持しない
     let h = unsafe { ctx.history.as_ref_unchecked() };
     let pcv = h.correction_history.pawn_value(pawn_idx, us) as i32;
@@ -92,19 +62,32 @@ pub(super) fn correction_value(
 
     // move無効の場合はcntcv全体が8（個別デフォルトの合計ではない）
     let cntcv = if move_ok {
+        let sentinel = std::ptr::NonNull::from(
+            h.correction_history.continuation_table(Piece::NONE, Square::SQ_11),
+        );
+        let table_2 = if ply >= 2 {
+            debug_assert!(((ply - 2) as usize) < st.stack.len());
+            // SAFETY: ply >= 2 かつ ply <= MAX_PLY なので (ply-2) はStackArrayの範囲内。
+            unsafe { st.stack.get_unchecked((ply - 2) as usize) }.cont_correction_ptr
+        } else {
+            sentinel
+        };
+        let table_4 = if ply >= 4 {
+            debug_assert!(((ply - 4) as usize) < st.stack.len());
+            // SAFETY: ply >= 4 かつ ply <= MAX_PLY なので (ply-4) はStackArrayの範囲内。
+            unsafe { st.stack.get_unchecked((ply - 4) as usize) }.cont_correction_ptr
+        } else {
+            sentinel
+        };
         let pc = pos.piece_on(prev_move.to());
-        let cv2 = h.correction_history.continuation_value(
-            cont_key_2.piece,
-            cont_key_2.to,
-            pc,
-            prev_move.to(),
-        ) as i32;
-        let cv4 = h.correction_history.continuation_value(
-            cont_key_4.piece,
-            cont_key_4.to,
-            pc,
-            prev_move.to(),
-        ) as i32;
+        // SAFETY: Stack上のpointerはHistoryCell内のtableまたはsentinelを指し、探索中は有効。
+        let cv2 = unsafe {
+            CorrectionHistory::continuation_value_from_table(table_2, pc, prev_move.to())
+        } as i32;
+        // SAFETY: 同上。
+        let cv4 = unsafe {
+            CorrectionHistory::continuation_value_from_table(table_4, pc, prev_move.to())
+        } as i32;
         cv2 + cv4
     } else {
         8

--- a/crates/rshogi-core/src/search/history.rs
+++ b/crates/rshogi-core/src/search/history.rs
@@ -14,6 +14,7 @@
 
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 use std::rc::Rc;
 
 use crate::types::{Color, Move, Piece, PieceType, Square};
@@ -693,6 +694,10 @@ impl Default for CounterMoveHistory {
 // CorrectionHistory
 // =============================================================================
 
+/// Continuation correction historyの1 context分: [piece][to] -> correction。
+pub type CorrectionPieceToHistory =
+    [[StatsEntry<CORRECTION_HISTORY_LIMIT>; Square::NUM]; Piece::NUM];
+
 /// CorrectionHistory ()
 ///
 /// - Pawn/Minor: [key_index][color] -> correction
@@ -705,8 +710,7 @@ pub struct CorrectionHistory {
     minor: [[StatsEntry<CORRECTION_HISTORY_LIMIT>; Color::NUM]; CORRECTION_HISTORY_SIZE],
     non_pawn:
         [[[StatsEntry<CORRECTION_HISTORY_LIMIT>; Color::NUM]; Color::NUM]; CORRECTION_HISTORY_SIZE],
-    continuation: [[[[StatsEntry<CORRECTION_HISTORY_LIMIT>; Square::NUM]; Piece::NUM]; Square::NUM];
-        Piece::NUM],
+    continuation: [[CorrectionPieceToHistory; Square::NUM]; Piece::NUM],
 }
 
 impl CorrectionHistory {
@@ -841,6 +845,28 @@ impl CorrectionHistory {
                 .get_unchecked(to.index())
                 .get()
         }
+    }
+
+    /// 指定した直前手contextの[piece][to]テーブルを返す。
+    #[inline]
+    pub fn continuation_table(&self, prev_pc: Piece, prev_to: Square) -> &CorrectionPieceToHistory {
+        // SAFETY: Piece::index() < Piece::NUM=31、Square::index() < Square::NUM=81。
+        unsafe { self.continuation.get_unchecked(prev_pc.index()).get_unchecked(prev_to.index()) }
+    }
+
+    /// 事前に選択済みのcontinuation correction tableから値を取得する。
+    ///
+    /// # Safety
+    ///
+    /// `table`は生存中の`CorrectionHistory::continuation_table()`を指していなければならない。
+    #[inline]
+    pub unsafe fn continuation_value_from_table(
+        table: NonNull<CorrectionPieceToHistory>,
+        pc: Piece,
+        to: Square,
+    ) -> i16 {
+        // SAFETY: 呼出側がtableの生存期間を保証し、Piece/Square indexは各NUM未満。
+        unsafe { table.as_ref().get_unchecked(pc.index()).get_unchecked(to.index()).get() }
     }
 
     #[inline]

--- a/crates/rshogi-core/src/search/search_helpers.rs
+++ b/crates/rshogi-core/src/search/search_helpers.rs
@@ -15,6 +15,7 @@ use crate::search::PieceToHistory;
 use crate::types::{Move, Piece, Square, Value};
 
 use super::alpha_beta::{SearchContext, SearchState};
+use super::history::CorrectionPieceToHistory;
 use super::types::{ContHistKey, STACK_SIZE};
 use super::{LimitsType, TimeManagement};
 
@@ -251,13 +252,19 @@ pub(super) fn set_cont_history_for_move(
     let in_check_idx = in_check as usize;
     let capture_idx = capture as usize;
     // SAFETY: 単一スレッド内で使用、可変参照と同時保持しない
-    let table = {
+    let (table, correction_table) = {
         let h = unsafe { ctx.history.as_ref_unchecked() };
-        NonNull::from(h.continuation_history[in_check_idx][capture_idx].get_table(piece, to))
+        (
+            NonNull::from(h.continuation_history[in_check_idx][capture_idx].get_table(piece, to)),
+            NonNull::<CorrectionPieceToHistory>::from(
+                h.correction_history.continuation_table(piece, to),
+            ),
+        )
     };
     // SAFETY: ply < MAX_PLY < STACK_SIZE は上の debug_assert で検証済み。
     let ss = unsafe { st.stack.get_unchecked_mut(ply as usize) };
     ss.cont_history_ptr = table;
+    ss.cont_correction_ptr = correction_table;
     ss.cont_hist_key = Some(ContHistKey::new(in_check, capture, piece, to));
 }
 
@@ -267,9 +274,15 @@ pub(super) fn set_cont_history_for_move(
 /// sentinel keyを設定してYOと同じsentinelテーブルへの読み書きが行われるようにする。
 #[inline]
 pub(super) fn clear_cont_history_for_null(st: &mut SearchState, ctx: &SearchContext<'_>, ply: i32) {
+    let correction_sentinel = {
+        // SAFETY: 単一スレッド内で使用、可変参照と同時保持しない。
+        let h = unsafe { ctx.history.as_ref_unchecked() };
+        NonNull::from(h.correction_history.continuation_table(Piece::NONE, Square::SQ_11))
+    };
     // SAFETY: ply < MAX_PLY < STACK_SIZE。
     let ss = unsafe { st.stack.get_unchecked_mut(ply as usize) };
     ss.cont_history_ptr = ctx.cont_history_sentinel;
+    ss.cont_correction_ptr = correction_sentinel;
     ss.cont_hist_key = Some(ContHistKey::null_sentinel());
 }
 

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -446,6 +446,7 @@ fn test_sentinel_initialization() {
 
     // sentinelポインタがdanglingではなく、実際のテーブルを指していることを確認
     let sentinel = worker.cont_history_sentinel;
+    let correction_sentinel = worker.cont_correction_sentinel;
     // NonNullはnullにならないことが保証されているので、
     // 代わりにsafeにderefできることを確認（ポインタが有効なメモリを指していること）
     let sentinel_ref = unsafe { sentinel.as_ref() };
@@ -455,6 +456,17 @@ fn test_sentinel_initialization() {
         crate::search::history::CONTINUATION_HISTORY_INIT,
         "sentinel table should be initialized with YO-standard value"
     );
+    // correction historyのsentinelはYOと同じ初期値8を持つ。
+    assert_eq!(
+        unsafe {
+            crate::search::history::CorrectionHistory::continuation_value_from_table(
+                correction_sentinel,
+                crate::types::Piece::B_PAWN,
+                crate::types::Square::SQ_11,
+            )
+        },
+        8
+    );
 
     // 全てのスタックエントリがsentinelで初期化されていることを確認
     for (i, stack) in worker.state.stack.iter().enumerate() {
@@ -462,5 +474,31 @@ fn test_sentinel_initialization() {
             stack.cont_history_ptr, sentinel,
             "stack[{i}].cont_history_ptr should be initialized to sentinel"
         );
+        assert_eq!(
+            stack.cont_correction_ptr, correction_sentinel,
+            "stack[{i}].cont_correction_ptr should be initialized to sentinel"
+        );
     }
+
+    // 未使用だったusize slotをpointerへ置き換えるため、hot Stackのfootprintは増やさない。
+    assert_eq!(std::mem::size_of::<crate::search::Stack>(), 56);
+}
+
+#[test]
+fn test_cont_correction_pointer_tracks_move_and_null() {
+    let tt = Arc::new(TranspositionTable::new(16));
+    let eval_hash = Arc::new(EvalHash::new(1));
+    let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+    let piece = crate::types::Piece::B_SILVER;
+    let to = crate::types::Square::SQ_55;
+
+    worker.set_cont_history_for_move(3, false, false, piece, to);
+    let expected = {
+        let history = unsafe { worker.history.as_ref_unchecked() };
+        std::ptr::NonNull::from(history.correction_history.continuation_table(piece, to))
+    };
+    assert_eq!(worker.state.stack[3].cont_correction_ptr, expected);
+
+    worker.clear_cont_history_for_null(3);
+    assert_eq!(worker.state.stack[3].cont_correction_ptr, worker.cont_correction_sentinel);
 }

--- a/crates/rshogi-core/src/search/types.rs
+++ b/crates/rshogi-core/src/search/types.rs
@@ -12,7 +12,7 @@ use crate::movegen::{MoveList, generate_legal_with_pass};
 use crate::position::Position;
 use crate::types::{MAX_PLY, Move, Piece, RepetitionState, Square, Value};
 
-use super::history::PieceToHistory;
+use super::history::{CorrectionPieceToHistory, PieceToHistory};
 use std::ptr::NonNull;
 
 // =============================================================================
@@ -166,8 +166,16 @@ pub struct Stack {
     /// tree-changing な探索改善でのみ参照する。
     pub follow_pv: bool,
 
-    /// ContinuationHistoryへの参照インデックス（旧方式、互換性のため残す）
-    pub cont_history_idx: usize,
+    /// ContinuationCorrectionHistoryへの参照（YaneuraOu方式）
+    ///
+    /// # Safety
+    ///
+    /// このポインタは以下の不変条件を満たす：
+    /// - 常に有効な`CorrectionPieceToHistory`テーブルを指す（`dangling()`は初期値のみ）
+    /// - `SearchWorker::reset_cont_history_ptrs()`でsentinelに初期化される
+    /// - 指し手実行時に`CorrectionHistory`内の対応テーブルへ更新される
+    /// - 参照先を所有する`HistoryCell`は`SearchWorker`の生存期間中に再配置されない
+    pub cont_correction_ptr: NonNull<CorrectionPieceToHistory>,
 
     /// ContinuationHistoryへの参照（YaneuraOu方式、MovePicker直結）
     ///
@@ -224,7 +232,7 @@ impl Default for Stack {
     fn default() -> Self {
         Self {
             follow_pv: false,
-            cont_history_idx: 0,
+            cont_correction_ptr: NonNull::dangling(),
             cont_history_ptr: NonNull::dangling(),
             cont_hist_key: None,
             ply: 0,


### PR DESCRIPTION
## 概要

Continuation correction history の参照時に4次元配列のcontext strideを毎回計算せず、YaneuraOuと同様に探索stackへ`[piece][to]` table pointerを保持します。

- 未使用だった8-byteの`cont_history_idx`をpointerへ置き換え、`Stack`は56 bytesのまま維持
- 通常手、root、null move、sentinel初期化の全経路でpointerを管理
- correction historyの更新側は既存のkey-based実装を維持
- production codegenの`correction_value`から大stride乗算4本を除去

## 性能

4局面、Threads=1、Hash=256 MiB、ABBA x3の集計です。

- 5秒: NPS +0.6341%、cycles/node -0.6517%、instructions/node -0.0380%
- 10秒: NPS +0.2815%、cycles/node -0.2746%、instructions/node -0.0885%
- 5秒・10秒の全6ラウンドでNPSとcycles/nodeが改善

局面別の符号は混在しており、10秒tacticalは悪化しています。一方で全体・ラウンド別・per-node指標が揃って改善し、探索木も不変だったため採用候補としました。

## 検証

- 4局面 x depth 1〜16の64ケースでnodes、score、PV、bestmoveが完全一致
- `cargo test -p rshogi-core`（lib 1002 passed / 6 ignored、integration 40 passed、doc tests 10 ignored）
- production editionの`cargo clippy -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- pointerの通常手更新、nullでのsentinel復帰、全stack sentinel、`Stack` 56 bytesをunit testで固定

Raw artifacts: `/mnt/nvme1/shogi-data/runs/perf/20260807-correction-pointer/`
