### PR TITLE
feat(tools): ek_testset に yardstick 用 hcpe export (export-hcpe) を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -64,7 +64,7 @@
 | `label_bench_positions` | ベンチ局面 jsonl を深い探索でラベル付けし `eval_deep` を追記（ground truth） |
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) で静的評価し `eval_dl` を追記（`dlshogi-onnx` feature、default 有効） |
 | `yardstick_label` / `yardstick_score` | ラベル品質「物差し」。held-out hcpe を labeler でラベル付け（stage 1）→ engine ごとに勝率較正して per-class WDL logloss / 参照天井 / リファレンス一致を採点（stage 2） |
-| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](docs/ek_testset.md)） |
+| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価または hcpe export → yardstick で採点（[詳細](docs/ek_testset.md)） |
 | `nyugyoku_metrics` | 終局 CSA から宣言ルール距離ペア（`%KACHI`）と探索読み切り詰み距離（`%TORYO` + oracle 探索）を抽出し、native NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点（[詳細](docs/nyugyoku_metrics.md)） |
 | `nnue_saturation` | LayerStacks NNUE の活性飽和率（ClippedReLU 127 張り付き）を実局面で計測（[詳細](docs/nnue_saturation.md)） |
 
@@ -113,7 +113,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [label_bench_dl](docs/label_bench_dl.md) - label_bench jsonl への DL水匠 (dlshogi ONNX) 評価値追記
 - [yardstick_label](docs/yardstick_label.md) - held-out hcpe を labeler の固定 depth 探索でラベル付け（物差し stage 1）
 - [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
-- [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
+- [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価または hcpe export → yardstick で採点
 - [nyugyoku_metrics](docs/nyugyoku_metrics.md) - 終局 CSA から宣言ルール距離ペアと探索読み切り詰み距離を抽出し、NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -42,12 +42,21 @@ core が `entering_king_point_info` を公開していないため、点数系�
 cargo run -p tools --release --bin ek_testset -- export-hcpe \
   --testset runs/ek_testset/band/testset.jsonl \
   --out runs/ek_testset/band/testset.hcpe \
-  --drop-draw false
+  --drop-draw false \
+  --allow-missing-eval true
 ```
+
+`build` の出力には `floodgate_eval_cp` が `null` のレコードが通常含まれます
+（終局局面のサンプルと、`'**` 評価コメントの無い手。定跡手・評価値を出さない
+エンジンなど）。そのため既定（`--allow-missing-eval false`）ではエラーで止まります。
+欠損レコードを除外して変換するには上記のように `--allow-missing-eval true` を
+指定してください。
 
 `yardstick_label` が読む cshogi HuffmanCodedPosAndEval（38B/レコード）へ、入力順を保って
 逐次変換します。局面は既存の HCP packer を使い、`floodgate_eval_cp` は手番側視点の i16 LE
-として保存します。i16 範囲外は clamp し、件数を標準エラーへ表示します。
+として保存します。i16 範囲外は clamp し、件数を標準エラーへ表示します（教師値スケールの
+汚染検知が目的のため、`--drop-draw` で出力から除外されたレコードの分も計上する入力側の
+件数です）。
 `bestMove16` は指し手なしを表す 0、`gameResult` は `oc_label` と `stm` から絶対視点へ変換、
 padding は 0 です。
 
@@ -58,9 +67,10 @@ padding は 0 です。
 指定した場合のみ該当レコードを**出力から除外**して続行し、除外件数
 （`eval_missing_skipped`）を標準エラーへ表示します。
 
-出力は `<out>.partial` へ書き、正常完了時のみ最終パスへ rename します（中断時の途中書きが
-正常な hcpe サイズのまま残らないようにするため）。入力と出力（`.partial` 含む）が同一実体の
-場合は truncate する前にエラーで拒否します。
+出力は `<out>.partial` へ書き、fsync してから正常完了時のみ最終パスへ rename します
+（中断時の途中書きが正常な hcpe サイズのまま残らないようにするため。途中失敗した
+`.partial` も削除します）。入力と出力（`.partial` 含む）が同一実体の場合、および出力が
+symlink の場合は truncate する前にエラーで拒否します。
 
 `--drop-draw` の既定値は `false` です。標準エラーの `draw` は入力で検出した draw 件数なので、
 `true` のときは出力件数に含まれません。`stm` と SFEN の手番が一致しないレコードは、

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -1,6 +1,8 @@
 # ek_testset
 
-`ek_testset` は、held-out CSA 棋譜から入玉局面の静的評価テストセットを作り、native NNUE 評価で採点するツールです。
+`ek_testset` は、held-out CSA 棋譜から入玉局面の評価テストセットを作るツールです。
+native NNUE の静的評価に加え、hcpe へ export して `yardstick_label` → `yardstick_score` で
+探索ラベル品質を採点できます。
 
 局面には 2 種類のラベルを付け、それぞれ別の指標系で採点します:
 
@@ -33,6 +35,37 @@ cargo run -p tools --release --bin ek_testset -- build \
 core が `entering_king_point_info` を公開していないため、点数系フィールド
 （`points_stm`, `king_in_enemy_stm`, `enemy_zone_pieces_stm`）は出力しません。DT ラベルは
 `Position::declaration_win(EnteringKingRule::Point27)` で作ります。
+
+## export-hcpe
+
+```bash
+cargo run -p tools --release --bin ek_testset -- export-hcpe \
+  --testset runs/ek_testset/band/testset.jsonl \
+  --out runs/ek_testset/band/testset.hcpe \
+  --drop-draw false
+```
+
+`yardstick_label` が読む cshogi HuffmanCodedPosAndEval（38B/レコード）へ、入力順を保って
+逐次変換します。局面は既存の HCP packer を使い、`floodgate_eval_cp` は手番側視点の i16 LE
+として保存します。i16 範囲外は clamp し、件数を標準エラーへ表示します。
+`bestMove16` は指し手なしを表す 0、`gameResult` は `oc_label` と `stm` から絶対視点へ変換、
+padding は 0 です。
+
+保存 eval は `yardstick_label`（stage 1）が eval_band / mate_ref の生成に読み、
+`yardstick_score`（stage 2）がそれを mate 除外・`a_ref` 較正・参照系指標に使うため、
+0 埋めすると採点を静かに歪めます。`floodgate_eval_cp` がない、
+または `null` のレコードは既定で行番号付きエラーです。`--allow-missing-eval true` を
+指定した場合のみ該当レコードを**出力から除外**して続行し、除外件数
+（`eval_missing_skipped`）を標準エラーへ表示します。
+
+出力は `<out>.partial` へ書き、正常完了時のみ最終パスへ rename します（中断時の途中書きが
+正常な hcpe サイズのまま残らないようにするため）。入力と出力（`.partial` 含む）が同一実体の
+場合は truncate する前にエラーで拒否します。
+
+`--drop-draw` の既定値は `false` です。標準エラーの `draw` は入力で検出した draw 件数なので、
+`true` のときは出力件数に含まれません。`stm` と SFEN の手番が一致しないレコードは、
+誤った教師値を作らないため行番号付きエラーにします。この検証は `--drop-draw` /
+`--allow-missing-eval` の除外判定より先に行うため、除外対象のレコードでも迂回されません。
 
 ## eval
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -26,7 +26,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `search_only_ab` | search-only A/B ベンチマーク。起動・ロード時間を除外して cycles/node, instructions/node を正確計測。Linux は `perf stat --control`、Windows は ETW NT Kernel Logger の PMC counting（要管理者権限、Hyper-V/VBS 共存可）。CLI 差異は `--perf-events`(Linux) ↔ `--pmc-sources`(Windows) の置き換えと、Windows での `--cpus` shard 並列未対応の 2 点。JSON レポートは `samples` / `summary` が両 OS でスキーマ互換（`cli` ブロックのみ `perf_events` / `pmc_sources` のフィールド名差があり非互換） |
 | `eval_sfens` | SFEN 局面を LayerStacks NNUE で静的評価（`score` は歩=90 の内部スケール、`score_cp` は cp） |
 | `nnue_saturation` | LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測（[詳細](nnue_saturation.md)） |
-| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](ek_testset.md)） |
+| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価または hcpe export → yardstick で採点（[詳細](ek_testset.md)） |
 | `nyugyoku_metrics` | 終局 CSA から宣言ルール距離ペア（`%KACHI`）と探索読み切り詰み距離（`%TORYO` + oracle 探索）を抽出し、native NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を対局クラスタ bootstrap CI 付きで採点（[詳細](nyugyoku_metrics.md)） |
 | `compare_eval_nnue` | 教師 NNUE と生徒 NNUE の評価値一致度を検証（MAE・相関係数・スコア帯別誤差） |
 | `dump_effect_bucket_golden` | 形式一致 golden 用に effect bucket active index を config 別に dump（[詳細](dump_effect_bucket_golden.md)） |

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -576,8 +576,10 @@ fn run_export_hcpe(args: &ExportHcpeArgs) -> Result<()> {
         )?;
         // rename 直後の電源断で最終パスにゼロ埋め/途中までの実体が残らないよう、
         // rename 前に fsync する。Windows は開いたままの rename に失敗し得るため、
-        // sync 後にここで閉じる。
-        writer.into_inner()?.sync_all()?;
+        // sync 後にここで閉じる。IntoInnerError は開いた writer を内包するため、
+        // into_error() で writer ごと破棄してから伝播する (開いたままだと後段の
+        // `.partial` 削除が Windows で失敗する)。
+        writer.into_inner().map_err(|err| err.into_error())?.sync_all()?;
         fs::rename(&tmp_output, &args.out).with_context(|| {
             format!("{} → {} の rename に失敗", tmp_output.display(), args.out.display())
         })?;
@@ -588,7 +590,15 @@ fn run_export_hcpe(args: &ExportHcpeArgs) -> Result<()> {
         Err(err) => {
             // 途中失敗の `.partial` は 38B の倍数の妥当なサイズになり得るため、
             // 偏った部分集合が誤って採点に使われないよう残さず消す。
-            let _ = fs::remove_file(&tmp_output);
+            // 削除失敗は元エラーを主に残しつつ警告で報告する。
+            if let Err(remove_err) = fs::remove_file(&tmp_output)
+                && remove_err.kind() != std::io::ErrorKind::NotFound
+            {
+                eprintln!(
+                    "warning: 一時ファイル {} を削除できません: {remove_err}",
+                    tmp_output.display()
+                );
+            }
             return Err(err);
         }
     };

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -542,24 +542,17 @@ fn run_export_hcpe(args: &ExportHcpeArgs) -> Result<()> {
     let tmp_output = partial_path(&args.out);
 
     // 入力と出力 (一時ファイル含む) が同一実体だと File::create が読み取り前に入力を
-    // truncate してしまうため拒否する。パス比較 (canonicalize) では hardlink
-    // (別パス・同一 inode) を検出できないので same-file の Handle で判定する。
-    let in_id = same_file::Handle::from_path(&args.testset)
-        .with_context(|| format!("testset のメタデータ取得に失敗: {}", args.testset.display()))?;
-    if same_file::Handle::from_path(&args.out).ok().as_ref() == Some(&in_id) {
-        bail!("入力と出力が同一ファイルです: {}", args.testset.display());
-    }
-    if same_file::Handle::from_path(&tmp_output).ok().as_ref() == Some(&in_id) {
-        bail!("一時ファイル {} が入力と同一です", tmp_output.display());
-    }
-    // File::open / File::create の前に Handle を閉じておく。
-    drop(in_id);
+    // truncate してしまうため拒否する。判定は crate 共通の ensure_safe_output_path に
+    // 委ねる (hardlink 検出・symlink 出力拒否・NotFound 以外の比較エラーを握り潰さない)。
+    crate::output_path::ensure_safe_output_path(&args.out, &args.testset)?;
+    crate::output_path::ensure_safe_output_path(&tmp_output, &args.testset)?;
 
     let input = File::open(&args.testset)
         .with_context(|| format!("testset を開けません: {}", args.testset.display()))?;
-    // 前回中断の残骸 `.partial` が既存 `<out>` や別ファイルへの hardlink/symlink だと
-    // File::create が追跡 truncate でリンク先を壊すため、entry を消してから新規作成する
+    // 前回中断の残骸 `.partial` が既存 `<out>` 等への hardlink だと File::create が
+    // 追跡 truncate でリンク先を壊すため、entry を消してから新規作成する
     // (「正常完了時のみ最終パスへ反映」の保証を staging 経路でも守る)。
+    // symlink の `.partial` は ensure_safe_output_path が先に拒否している。
     if let Err(err) = fs::remove_file(&tmp_output)
         && err.kind() != std::io::ErrorKind::NotFound
     {
@@ -572,20 +565,33 @@ fn run_export_hcpe(args: &ExportHcpeArgs) -> Result<()> {
         .create_new(true)
         .open(&tmp_output)
         .with_context(|| format!("hcpe を出力できません: {}", tmp_output.display()))?;
-    let mut writer = BufWriter::new(output);
-    let stats = export_hcpe(
-        BufReader::new(input),
-        &mut writer,
-        &args.testset,
-        args.drop_draw,
-        args.allow_missing_eval,
-    )?;
-    writer.flush()?;
-    // Windows は開いたままの rename に失敗し得るため、先に閉じる。
-    drop(writer);
-    fs::rename(&tmp_output, &args.out).with_context(|| {
-        format!("{} → {} の rename に失敗", tmp_output.display(), args.out.display())
-    })?;
+    let result = (|| -> Result<ExportHcpeStats> {
+        let mut writer = BufWriter::new(output);
+        let stats = export_hcpe(
+            BufReader::new(input),
+            &mut writer,
+            &args.testset,
+            args.drop_draw,
+            args.allow_missing_eval,
+        )?;
+        // rename 直後の電源断で最終パスにゼロ埋め/途中までの実体が残らないよう、
+        // rename 前に fsync する。Windows は開いたままの rename に失敗し得るため、
+        // sync 後にここで閉じる。
+        writer.into_inner()?.sync_all()?;
+        fs::rename(&tmp_output, &args.out).with_context(|| {
+            format!("{} → {} の rename に失敗", tmp_output.display(), args.out.display())
+        })?;
+        Ok(stats)
+    })();
+    let stats = match result {
+        Ok(stats) => stats,
+        Err(err) => {
+            // 途中失敗の `.partial` は 38B の倍数の妥当なサイズになり得るため、
+            // 偏った部分集合が誤って採点に使われないよう残さず消す。
+            let _ = fs::remove_file(&tmp_output);
+            return Err(err);
+        }
+    };
 
     eprintln!("{}", export_hcpe_summary(&stats, &args.out));
     Ok(())
@@ -635,6 +641,10 @@ fn export_hcpe<R: BufRead, W: Write>(
                 format!("{}:{}: hcpe レコードへ変換できません", input_path.display(), line_no + 1)
             })?;
 
+        // clamp は教師値スケールの汚染検知が目的なので、--drop-draw で出力から
+        // 除外されるレコードの分も入力側で計上する。
+        stats.eval_clamped += usize::from(eval_clamped);
+
         if eval_missing {
             if !allow_missing_eval {
                 bail!(
@@ -661,7 +671,6 @@ fn export_hcpe<R: BufRead, W: Write>(
 
         writer.write_all(&bytes)?;
         stats.output_records += 1;
-        stats.eval_clamped += usize::from(eval_clamped);
     }
     Ok(stats)
 }
@@ -1302,7 +1311,7 @@ mod tests {
             allow_missing_eval: false,
         })
         .expect_err("same input/output must be rejected");
-        assert!(format!("{err:#}").contains("同一ファイル"));
+        assert!(format!("{err:#}").contains("resolves to input file"));
         assert!(fs::metadata(&testset).expect("input must survive").len() > 0);
 
         // 正常系は .partial 経由で最終パスへ rename され、.partial は残らない。
@@ -1335,7 +1344,7 @@ mod tests {
             allow_missing_eval: false,
         })
         .expect_err("hardlinked output must be rejected");
-        assert!(format!("{err:#}").contains("同一ファイル"));
+        assert!(format!("{err:#}").contains("resolves to input file"));
 
         // `.partial` が入力への hardlink。
         let out = dir.path().join("out.hcpe");
@@ -1347,7 +1356,7 @@ mod tests {
             allow_missing_eval: false,
         })
         .expect_err("hardlinked .partial must be rejected");
-        assert!(format!("{err:#}").contains("入力と同一"));
+        assert!(format!("{err:#}").contains("resolves to input file"));
 
         // どちらの経路でも入力は無傷。
         assert_eq!(fs::read(&testset).expect("read input back"), content);
@@ -1376,8 +1385,9 @@ mod tests {
         })
         .expect_err("missing eval must fail the export");
 
-        // 途中失敗では既存出力を truncate も置換もしない。
+        // 途中失敗では既存出力を truncate も置換もせず、書きかけの `.partial` も残さない。
         assert_eq!(fs::read(&out).expect("existing output survives"), b"sentinel");
+        assert!(!partial_path(&out).exists());
     }
 
     #[test]

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -4,7 +4,7 @@
 //! `Position::declaration_win(EnteringKingRule::Point27)` を使う。core が
 //! `entering_king_point_info` を公開していないため、点数系フィールドは JSONL に出さない。
 
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
@@ -21,8 +21,11 @@ use rshogi_core::types::{Color, EnteringKingRule, Move, Rank};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
+use crate::common::io::partial_path;
+use crate::packed_sfen::{pack_position_hcp, stm_result_to_hcpe};
 use crate::replay::csa_source::CsaSource;
 use crate::replay::model::{GameIndex, GameIndexEntry, GameOutcomeView, GameSource, MoveView};
+use crate::teacher_labeler::HCPE_RECORD_SIZE;
 
 const DEFAULT_MIN_PLY_FROM_ENTRY: i32 = -20;
 const DEFAULT_SAMPLE_STRIDE: u32 = 4;
@@ -35,7 +38,7 @@ const PROB_EPS: f64 = 1e-12;
 #[command(
     name = "ek_testset",
     version,
-    about = "入玉評価テストセットを CSA から構築し、NNUE 静的評価で採点する"
+    about = "入玉評価テストセットを CSA から構築し、NNUE 静的評価または hcpe export → yardstick で採点する"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -48,6 +51,8 @@ enum Command {
     Build(BuildArgs),
     /// testset.jsonl を native NNUE 評価で採点する。
     Eval(EvalArgs),
+    /// testset.jsonl を yardstick_label 用 hcpe へ変換する。
+    ExportHcpe(ExportHcpeArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -87,6 +92,22 @@ struct EvalArgs {
     /// metrics.json の出力先。
     #[arg(long)]
     out: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+struct ExportHcpeArgs {
+    /// `ek_testset build` が出した testset.jsonl。
+    #[arg(long)]
+    testset: PathBuf,
+    /// hcpe（38B/レコード）の出力先。
+    #[arg(long)]
+    out: PathBuf,
+    /// draw レコードを出力から除外するか。
+    #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
+    drop_draw: bool,
+    /// `floodgate_eval_cp` 欠損レコードをエラーにせず出力から除外して続行するか。
+    #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
+    allow_missing_eval: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -228,12 +249,21 @@ struct PositionSample {
     floodgate_eval_cp: Option<i32>,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ExportHcpeStats {
+    output_records: usize,
+    draw_records: usize,
+    eval_clamped: usize,
+    eval_missing: usize,
+}
+
 /// CLI entrypoint。
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Build(args) => run_build(&args),
         Command::Eval(args) => run_eval(&args),
+        Command::ExportHcpe(args) => run_export_hcpe(&args),
     }
 }
 
@@ -506,6 +536,173 @@ fn color_label(c: Color) -> char {
     }
 }
 
+fn run_export_hcpe(args: &ExportHcpeArgs) -> Result<()> {
+    // 中断時の途中書きが正常な hcpe サイズ (38B の倍数) で残らないよう、`.partial` へ
+    // 書いて成功時のみ最終パスへ rename する (hcpe_to_psv と同じ方式)。
+    let tmp_output = partial_path(&args.out);
+
+    // 入力と出力 (一時ファイル含む) が同一実体だと File::create が読み取り前に入力を
+    // truncate してしまうため拒否する。パス比較 (canonicalize) では hardlink
+    // (別パス・同一 inode) を検出できないので same-file の Handle で判定する。
+    let in_id = same_file::Handle::from_path(&args.testset)
+        .with_context(|| format!("testset のメタデータ取得に失敗: {}", args.testset.display()))?;
+    if same_file::Handle::from_path(&args.out).ok().as_ref() == Some(&in_id) {
+        bail!("入力と出力が同一ファイルです: {}", args.testset.display());
+    }
+    if same_file::Handle::from_path(&tmp_output).ok().as_ref() == Some(&in_id) {
+        bail!("一時ファイル {} が入力と同一です", tmp_output.display());
+    }
+    // File::open / File::create の前に Handle を閉じておく。
+    drop(in_id);
+
+    let input = File::open(&args.testset)
+        .with_context(|| format!("testset を開けません: {}", args.testset.display()))?;
+    // 前回中断の残骸 `.partial` が既存 `<out>` や別ファイルへの hardlink/symlink だと
+    // File::create が追跡 truncate でリンク先を壊すため、entry を消してから新規作成する
+    // (「正常完了時のみ最終パスへ反映」の保証を staging 経路でも守る)。
+    if let Err(err) = fs::remove_file(&tmp_output)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(err).with_context(|| {
+            format!("既存の一時ファイル {} を削除できません", tmp_output.display())
+        });
+    }
+    let output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_output)
+        .with_context(|| format!("hcpe を出力できません: {}", tmp_output.display()))?;
+    let mut writer = BufWriter::new(output);
+    let stats = export_hcpe(
+        BufReader::new(input),
+        &mut writer,
+        &args.testset,
+        args.drop_draw,
+        args.allow_missing_eval,
+    )?;
+    writer.flush()?;
+    // Windows は開いたままの rename に失敗し得るため、先に閉じる。
+    drop(writer);
+    fs::rename(&tmp_output, &args.out).with_context(|| {
+        format!("{} → {} の rename に失敗", tmp_output.display(), args.out.display())
+    })?;
+
+    eprintln!("{}", export_hcpe_summary(&stats, &args.out));
+    Ok(())
+}
+
+fn export_hcpe_summary(stats: &ExportHcpeStats, output_path: &Path) -> String {
+    let mut summary = format!(
+        "wrote {} records (draw={}, eval_clamped={}, eval_missing_skipped={}) to {}",
+        stats.output_records,
+        stats.draw_records,
+        stats.eval_clamped,
+        stats.eval_missing,
+        output_path.display(),
+    );
+    if stats.eval_missing > 0 {
+        summary.push_str(&format!(
+            "\nfloodgate_eval_cp 欠損 {} 件は出力から除外しました (yardstick は保存 eval から \
+             eval_band / mate_ref を作って採点に使うため 0 埋めしない)。",
+            stats.eval_missing
+        ));
+    }
+    summary
+}
+
+fn export_hcpe<R: BufRead, W: Write>(
+    reader: R,
+    writer: &mut W,
+    input_path: &Path,
+    drop_draw: bool,
+    allow_missing_eval: bool,
+) -> Result<ExportHcpeStats> {
+    let mut stats = ExportHcpeStats::default();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line
+            .with_context(|| format!("{}:{}: 行を読めません", input_path.display(), line_no + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: TestsetRecord = serde_json::from_str(&line).with_context(|| {
+            format!("{}:{}: JSON を読めません", input_path.display(), line_no + 1)
+        })?;
+
+        // 検証 (stm/SFEN 整合・盤面 pack) は除外判定より先に行い、--drop-draw や
+        // --allow-missing-eval が整合検査を迂回しないようにする。
+        let (bytes, eval_clamped, eval_missing) =
+            encode_hcpe_record(&record).with_context(|| {
+                format!("{}:{}: hcpe レコードへ変換できません", input_path.display(), line_no + 1)
+            })?;
+
+        if eval_missing {
+            if !allow_missing_eval {
+                bail!(
+                    "{}:{}: floodgate_eval_cp がありません。yardstick_label は保存 eval から \
+                     eval_band / mate_ref を作り、yardstick_score が mate 除外・a_ref 較正・\
+                     参照系指標に使うため 0 埋めできません。該当レコードを除外して続行するには \
+                     --allow-missing-eval true を指定してください",
+                    input_path.display(),
+                    line_no + 1
+                );
+            }
+            stats.eval_missing += 1;
+            if record.oc_label == Label::Draw {
+                stats.draw_records += 1;
+            }
+            continue;
+        }
+        if record.oc_label == Label::Draw {
+            stats.draw_records += 1;
+            if drop_draw {
+                continue;
+            }
+        }
+
+        writer.write_all(&bytes)?;
+        stats.output_records += 1;
+        stats.eval_clamped += usize::from(eval_clamped);
+    }
+    Ok(stats)
+}
+
+fn encode_hcpe_record(record: &TestsetRecord) -> Result<([u8; HCPE_RECORD_SIZE], bool, bool)> {
+    let stm = match record.stm {
+        'b' => Color::Black,
+        'w' => Color::White,
+        other => bail!("stm は b/w のいずれかである必要があります: {other}"),
+    };
+
+    let mut pos = Position::new();
+    pos.set_sfen(&record.sfen)
+        .with_context(|| format!("SFEN を読めません: {}", record.sfen))?;
+    if pos.side_to_move() != stm {
+        bail!(
+            "stm ({}) と SFEN の手番 ({}) が一致しません",
+            record.stm,
+            color_label(pos.side_to_move())
+        );
+    }
+
+    let eval_missing = record.floodgate_eval_cp.is_none();
+    let eval_cp = record.floodgate_eval_cp.unwrap_or(0);
+    let clamped_eval = eval_cp.clamp(i32::from(i16::MIN), i32::from(i16::MAX));
+    let eval_clamped = clamped_eval != eval_cp;
+    let stored_eval = i16::try_from(clamped_eval).expect("i16 範囲へ clamp 済み");
+    let stm_result = match record.oc_label {
+        Label::Win => 1,
+        Label::Loss => -1,
+        Label::Draw => 0,
+    };
+
+    let mut bytes = [0u8; HCPE_RECORD_SIZE];
+    bytes[0..32].copy_from_slice(&pack_position_hcp(&pos));
+    bytes[32..34].copy_from_slice(&stored_eval.to_le_bytes());
+    // bestMove16 は「指し手なし」の 0。padding も初期値の 0 のままにする。
+    bytes[36] = stm_result_to_hcpe(stm_result, stm);
+    Ok((bytes, eval_clamped, eval_missing))
+}
+
 fn run_eval(args: &EvalArgs) -> Result<()> {
     if !args.scale.is_finite() || args.scale <= 0.0 {
         bail!("--scale は正の有限値を指定してください");
@@ -739,6 +936,31 @@ fn sigmoid(x: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packed_sfen::{pack_position, unpack_hcp};
+
+    const STARTPOS_BOARD: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL";
+
+    fn export_record(stm: char, oc_label: Label, eval_cp: i32) -> TestsetRecord {
+        TestsetRecord {
+            sfen: format!("{STARTPOS_BOARD} {stm} - 1"),
+            stm,
+            ply: 1,
+            source_csa: "game.csa".to_string(),
+            is_declarable: false,
+            dt_label: None,
+            oc_label,
+            floodgate_eval_cp: Some(eval_cp),
+        }
+    }
+
+    fn records_jsonl(records: &[TestsetRecord]) -> Vec<u8> {
+        let mut input = Vec::new();
+        for record in records {
+            serde_json::to_writer(&mut input, record).expect("serialize record");
+            input.push(b'\n');
+        }
+        input
+    }
 
     fn write_csa(dir: &Path, name: &str, text: &str) -> PathBuf {
         let path = dir.join(name);
@@ -788,6 +1010,374 @@ mod tests {
             panic!("build expected")
         };
         assert!(args.drop_draw);
+    }
+
+    #[test]
+    fn export_hcpe_drop_draw_flag_is_settable() {
+        let base = [
+            "ek_testset",
+            "export-hcpe",
+            "--testset",
+            "in.jsonl",
+            "--out",
+            "out.hcpe",
+        ];
+        let cli = Cli::try_parse_from(base).expect("parse default");
+        let Command::ExportHcpe(args) = cli.command else {
+            panic!("export-hcpe expected")
+        };
+        assert!(!args.drop_draw);
+
+        let with_true = base.iter().chain(&["--drop-draw", "true"]);
+        let cli = Cli::try_parse_from(with_true).expect("parse --drop-draw true");
+        let Command::ExportHcpe(args) = cli.command else {
+            panic!("export-hcpe expected")
+        };
+        assert!(args.drop_draw);
+        assert!(!args.allow_missing_eval);
+
+        let with_allow = base.iter().chain(&["--allow-missing-eval", "true"]);
+        let cli = Cli::try_parse_from(with_allow).expect("parse --allow-missing-eval true");
+        let Command::ExportHcpe(args) = cli.command else {
+            panic!("export-hcpe expected")
+        };
+        assert!(args.allow_missing_eval);
+    }
+
+    #[test]
+    fn export_hcpe_round_trips_position_with_existing_hcp_reader() {
+        let record = export_record('w', Label::Win, 123);
+        let (bytes, eval_clamped, eval_missing) = encode_hcpe_record(&record).expect("encode hcpe");
+        assert!(!eval_clamped);
+        assert!(!eval_missing);
+
+        let mut hcp = [0u8; 32];
+        hcp.copy_from_slice(&bytes[0..32]);
+        let decoded_sfen = unpack_hcp(&hcp).expect("unpack hcp");
+        let mut decoded = Position::new();
+        decoded.set_sfen(&decoded_sfen).expect("set decoded SFEN");
+        let mut original = Position::new();
+        original.set_sfen(&record.sfen).expect("set original SFEN");
+
+        assert_eq!(pack_position(&decoded), pack_position(&original));
+        assert_eq!(bytes[34..36], [0, 0]);
+        assert_eq!(bytes[37], 0);
+    }
+
+    #[test]
+    fn export_hcpe_converts_stm_results_to_absolute_results() {
+        for (stm, label, expected) in [
+            ('b', Label::Win, 1),
+            ('b', Label::Loss, 2),
+            ('w', Label::Win, 2),
+            ('w', Label::Loss, 1),
+        ] {
+            let record = export_record(stm, label, 0);
+            let (bytes, _, _) = encode_hcpe_record(&record).expect("encode hcpe");
+            assert_eq!(bytes[36], expected, "stm={stm} label={label:?}");
+        }
+    }
+
+    #[test]
+    fn export_hcpe_keeps_or_drops_draws() {
+        let records = [
+            export_record('b', Label::Win, 10),
+            export_record('w', Label::Draw, -20),
+        ];
+        let input = records_jsonl(&records);
+
+        let mut kept = Vec::new();
+        let kept_stats = export_hcpe(
+            std::io::Cursor::new(&input),
+            &mut kept,
+            Path::new("testset.jsonl"),
+            false,
+            false,
+        )
+        .expect("export with draws");
+        assert_eq!(
+            kept_stats,
+            ExportHcpeStats {
+                output_records: 2,
+                draw_records: 1,
+                eval_clamped: 0,
+                eval_missing: 0,
+            }
+        );
+        assert_eq!(kept.len(), 2 * HCPE_RECORD_SIZE);
+        assert_eq!(kept[HCPE_RECORD_SIZE + 36], 0);
+
+        let mut dropped = Vec::new();
+        let dropped_stats = export_hcpe(
+            std::io::Cursor::new(&input),
+            &mut dropped,
+            Path::new("testset.jsonl"),
+            true,
+            false,
+        )
+        .expect("export without draws");
+        assert_eq!(
+            dropped_stats,
+            ExportHcpeStats {
+                output_records: 1,
+                draw_records: 1,
+                eval_clamped: 0,
+                eval_missing: 0,
+            }
+        );
+        assert_eq!(dropped.len(), HCPE_RECORD_SIZE);
+    }
+
+    #[test]
+    fn export_hcpe_clamps_eval_to_i16_boundaries() {
+        for (input, expected, was_clamped) in [
+            (i32::from(i16::MIN) - 1, i16::MIN, true),
+            (i32::from(i16::MIN), i16::MIN, false),
+            (i32::from(i16::MAX), i16::MAX, false),
+            (i32::from(i16::MAX) + 1, i16::MAX, true),
+        ] {
+            let record = export_record('b', Label::Win, input);
+            let (bytes, actual_clamped, eval_missing) =
+                encode_hcpe_record(&record).expect("encode hcpe");
+            assert_eq!(i16::from_le_bytes([bytes[32], bytes[33]]), expected);
+            assert_eq!(actual_clamped, was_clamped);
+            assert!(!eval_missing);
+        }
+    }
+
+    fn missing_eval_jsonl() -> Vec<u8> {
+        // TestsetRecord は skip_serializing_if 付きなので、明示 `null` ケースは
+        // serde_json::Value 経由で作る (struct を serialize するとフィールド欠落になる)。
+        let mut null_eval = serde_json::to_value(export_record('b', Label::Win, 1))
+            .expect("serialize null-eval record");
+        null_eval["floodgate_eval_cp"] = serde_json::Value::Null;
+        let mut missing_eval = serde_json::to_value(export_record('w', Label::Loss, 2))
+            .expect("serialize missing-eval record");
+        missing_eval
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("floodgate_eval_cp");
+        let following = export_record('b', Label::Draw, 345);
+
+        let mut input = Vec::new();
+        serde_json::to_writer(&mut input, &null_eval).expect("serialize null-eval record");
+        input.push(b'\n');
+        serde_json::to_writer(&mut input, &missing_eval).expect("serialize missing-eval record");
+        input.push(b'\n');
+        serde_json::to_writer(&mut input, &following).expect("serialize following record");
+        input.push(b'\n');
+        input
+    }
+
+    #[test]
+    fn export_hcpe_missing_eval_is_an_error_by_default() {
+        let input = missing_eval_jsonl();
+        let mut output = Vec::new();
+        let err = export_hcpe(
+            std::io::Cursor::new(input),
+            &mut output,
+            Path::new("testset.jsonl"),
+            false,
+            false,
+        )
+        .expect_err("missing eval must error by default");
+        let message = format!("{err:#}");
+        assert!(message.contains("testset.jsonl:1"), "unexpected error: {message}");
+        assert!(message.contains("--allow-missing-eval"), "unexpected error: {message}");
+    }
+
+    #[test]
+    fn export_hcpe_skips_missing_evals_when_allowed() {
+        let input = missing_eval_jsonl();
+        let mut output = Vec::new();
+        let stats = export_hcpe(
+            std::io::Cursor::new(input),
+            &mut output,
+            Path::new("testset.jsonl"),
+            false,
+            true,
+        )
+        .expect("export with --allow-missing-eval");
+
+        assert_eq!(
+            stats,
+            ExportHcpeStats {
+                output_records: 1,
+                draw_records: 1,
+                eval_clamped: 0,
+                eval_missing: 2,
+            }
+        );
+        // 欠損 2 件は出力されず、eval ありの 1 件 (345) だけが残る。
+        assert_eq!(output.len(), HCPE_RECORD_SIZE);
+        assert_eq!(i16::from_le_bytes([output[32], output[33]]), 345);
+
+        let summary = export_hcpe_summary(&stats, Path::new("out.hcpe"));
+        assert!(summary.contains("eval_missing_skipped=2"));
+        assert!(summary.contains("欠損 2 件は出力から除外しました"));
+    }
+
+    #[test]
+    fn export_hcpe_validates_even_when_missing_eval_is_allowed() {
+        // --allow-missing-eval true は欠損 eval の除外だけを許可し、stm/SFEN 整合検査は
+        // 迂回しない。
+        let mut record = export_record('b', Label::Win, 0);
+        record.stm = 'w';
+        record.floodgate_eval_cp = None;
+        let input = records_jsonl(&[record]);
+
+        let mut output = Vec::new();
+        let err = export_hcpe(
+            std::io::Cursor::new(input),
+            &mut output,
+            Path::new("testset.jsonl"),
+            false,
+            true,
+        )
+        .expect_err("mismatched stm must error even with --allow-missing-eval");
+        assert!(format!("{err:#}").contains("一致しません"));
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn export_hcpe_counts_overlapping_draw_and_missing_eval_once_each() {
+        let mut record = export_record('b', Label::Draw, 0);
+        record.floodgate_eval_cp = None;
+        let input = records_jsonl(&[record]);
+
+        let mut output = Vec::new();
+        let stats = export_hcpe(
+            std::io::Cursor::new(input),
+            &mut output,
+            Path::new("testset.jsonl"),
+            false,
+            true,
+        )
+        .expect("export draw+missing record");
+        assert_eq!(
+            stats,
+            ExportHcpeStats {
+                output_records: 0,
+                draw_records: 1,
+                eval_clamped: 0,
+                eval_missing: 1,
+            }
+        );
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn export_hcpe_validates_records_before_dropping_draws() {
+        // stm と SFEN の手番が矛盾した draw レコードは --drop-draw true でもエラーにする
+        // (除外パスが整合検査を迂回しない)。
+        let mut record = export_record('b', Label::Draw, 0);
+        record.stm = 'w';
+        let input = records_jsonl(&[record]);
+
+        let mut output = Vec::new();
+        let err = export_hcpe(
+            std::io::Cursor::new(input),
+            &mut output,
+            Path::new("testset.jsonl"),
+            true,
+            false,
+        )
+        .expect_err("mismatched stm must error even for dropped draws");
+        assert!(format!("{err:#}").contains("一致しません"));
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn run_export_hcpe_rejects_same_input_and_output_and_stages_partial() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let testset = dir.path().join("testset.jsonl");
+        fs::write(&testset, records_jsonl(&[export_record('b', Label::Win, 10)]))
+            .expect("write testset");
+
+        // 入力と出力が同一実体なら truncate 前に拒否し、入力を壊さない。
+        let err = run_export_hcpe(&ExportHcpeArgs {
+            testset: testset.clone(),
+            out: testset.clone(),
+            drop_draw: false,
+            allow_missing_eval: false,
+        })
+        .expect_err("same input/output must be rejected");
+        assert!(format!("{err:#}").contains("同一ファイル"));
+        assert!(fs::metadata(&testset).expect("input must survive").len() > 0);
+
+        // 正常系は .partial 経由で最終パスへ rename され、.partial は残らない。
+        let out = dir.path().join("out.hcpe");
+        run_export_hcpe(&ExportHcpeArgs {
+            testset: testset.clone(),
+            out: out.clone(),
+            drop_draw: false,
+            allow_missing_eval: false,
+        })
+        .expect("export to a fresh output");
+        assert_eq!(fs::metadata(&out).expect("output exists").len(), HCPE_RECORD_SIZE as u64);
+        assert!(!partial_path(&out).exists());
+    }
+
+    #[test]
+    fn run_export_hcpe_rejects_hardlinks_to_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let testset = dir.path().join("testset.jsonl");
+        let content = records_jsonl(&[export_record('b', Label::Win, 10)]);
+        fs::write(&testset, &content).expect("write testset");
+
+        // 出力が入力への hardlink (別パス・同一実体)。
+        let out_link = dir.path().join("out-link.hcpe");
+        fs::hard_link(&testset, &out_link).expect("hardlink out");
+        let err = run_export_hcpe(&ExportHcpeArgs {
+            testset: testset.clone(),
+            out: out_link,
+            drop_draw: false,
+            allow_missing_eval: false,
+        })
+        .expect_err("hardlinked output must be rejected");
+        assert!(format!("{err:#}").contains("同一ファイル"));
+
+        // `.partial` が入力への hardlink。
+        let out = dir.path().join("out.hcpe");
+        fs::hard_link(&testset, partial_path(&out)).expect("hardlink partial");
+        let err = run_export_hcpe(&ExportHcpeArgs {
+            testset: testset.clone(),
+            out,
+            drop_draw: false,
+            allow_missing_eval: false,
+        })
+        .expect_err("hardlinked .partial must be rejected");
+        assert!(format!("{err:#}").contains("入力と同一"));
+
+        // どちらの経路でも入力は無傷。
+        assert_eq!(fs::read(&testset).expect("read input back"), content);
+    }
+
+    #[test]
+    fn run_export_hcpe_failure_keeps_existing_output_intact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let testset = dir.path().join("testset.jsonl");
+        // 1 行目は変換に成功し、2 行目の欠損 eval で失敗する入力。
+        let ok = export_record('b', Label::Win, 10);
+        let mut broken = export_record('w', Label::Loss, 0);
+        broken.floodgate_eval_cp = None;
+        fs::write(&testset, records_jsonl(&[ok, broken])).expect("write testset");
+
+        // 既存の最終出力と、それへの hardlink として残った前回の `.partial`。
+        let out = dir.path().join("out.hcpe");
+        fs::write(&out, b"sentinel").expect("write existing output");
+        fs::hard_link(&out, partial_path(&out)).expect("stale partial hardlink");
+
+        run_export_hcpe(&ExportHcpeArgs {
+            testset,
+            out: out.clone(),
+            drop_draw: false,
+            allow_missing_eval: false,
+        })
+        .expect_err("missing eval must fail the export");
+
+        // 途中失敗では既存出力を truncate も置換もしない。
+        assert_eq!(fs::read(&out).expect("existing output survives"), b"sentinel");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`ek_testset build` が出力する入玉評価テストセット (testset.jsonl) を、`yardstick_label` が読む cshogi HuffmanCodedPosAndEval (38B/レコード) へ入力順を保って逐次変換する `export-hcpe` サブコマンドを追加する。native NNUE 静的評価 (`eval`) に加えて、hcpe export → yardstick 系で探索ラベル品質を採点する導線を作るのが目的。

## 設計上のポイント

- **欠損 eval は 0 埋めしない**: 保存 eval は `yardstick_label` (stage 1) が eval_band / mate_ref の生成に読み、`yardstick_score` (stage 2) が mate 除外・a_ref 較正・参照系指標に使うため、0 埋めは採点を静かに歪める。`floodgate_eval_cp` 欠損は既定で行番号付きエラーとし、`--allow-missing-eval true` 指定時のみ該当レコードを出力から除外して続行する
- **staging 書き込み**: `<out>.partial` へ書いて成功時のみ rename (正典 `hcpe_to_psv` と同方式)。入力と出力 (`.partial` 含む) の同一実体は same-file Handle で拒否 (hardlink も検出)。stale `.partial` が既存出力等への hardlink/symlink の場合も、entry を削除してから `create_new` で作るためリンク先を壊さない
- **検証は除外判定より先**: stm/SFEN 整合検査を `--drop-draw` / `--allow-missing-eval` の除外判定より先に実行し、除外パスでの検査迂回を防ぐ
- i16 範囲外の eval は clamp して件数報告。`bestMove16` は 0、`gameResult` は `oc_label` と `stm` から絶対視点へ変換

## テスト

- 新規 9 件を含む ek_testset テスト 21 件 pass (`cargo test -p tools`)
- hardlink 経由の同一実体拒否、途中失敗時の既存出力保全、明示 `null` eval、draw ∩ 欠損 eval の stats 計上、除外パスの検証迂回防止をそれぞれ実検証
- fmt / clippy / check-tracked-abs-paths 通過

## レビュー

ローカルで Codex + Claude の独立 dual review を 2 巡実施し、両者 APPROVE 済み (1 巡目の Codex High 指摘 = stale `.partial` の alias truncate も修正済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)