### PR TITLE
ci: claude-review デバッグ (show_full_output 一時有効化)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Claude Code Review が 2026-08-12 の #994 (claude-code-action 1.0.170→1.0.185 bump) 以降毎回 is_error:true で失敗している。エラー本文が hidden のため、本 PR で show_full_output を有効化して実エラーを観測する (merge しない調査用 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127vB668GtsSgFjc1eJWsCG