### PR TITLE
feat(nnue): LayerStacks net 係数への整数 delta 注入 (net 重み SPSA の engine 側)

### DIFF
--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -145,6 +145,30 @@ impl DynamicAffine {
         })
     }
 
+    pub(crate) fn weight_len(&self) -> usize {
+        self.weights.len()
+    }
+
+    pub(crate) fn file_weight(&self, index: usize) -> i8 {
+        self.weights[index]
+    }
+
+    pub(crate) fn apply_file_weight_delta(&mut self, index: usize, delta: i32) -> bool {
+        let (value, clamped) = super::net_delta::add_i8_delta(self.weights[index], delta);
+        self.weights[index] = value;
+        clamped
+    }
+
+    pub(crate) fn bias(&self, index: usize) -> i32 {
+        self.biases[index]
+    }
+
+    pub(crate) fn apply_bias_delta(&mut self, index: usize, delta: i32) -> bool {
+        let (value, clamped) = super::net_delta::add_i32_delta(self.biases[index], delta);
+        self.biases[index] = value;
+        clamped
+    }
+
     #[inline]
     pub(crate) fn propagate(&self, input: &[u8], output: &mut [i32]) {
         debug_assert!(input.len() >= self.padded_input);
@@ -638,6 +662,7 @@ mod tests {
     use super::*;
     use crate::nnue::accumulator_stack_variant::AccumulatorStackVariant;
     use crate::nnue::halfkp::{HalfKPNetwork, HalfKPStack};
+    use crate::nnue::net_delta::{NetCoefficientId, NetDelta, NetTensorKind};
     use crate::nnue::network::NNUENetwork;
     use crate::position::SFEN_HIRATE;
 
@@ -648,6 +673,36 @@ mod tests {
             output_dim,
             biases: AlignedBox::new_zeroed(output_dim),
             weights: AlignedBox::new_zeroed(output_dim * padded_input(input_dim)),
+        }
+    }
+
+    #[test]
+    fn dynamic_affine_file_edit_matches_delta() {
+        for (input_dim, output_dim) in [(30, 32), (32, 1)] {
+            let weight_len = output_dim * padded_input(input_dim);
+            let file_index = weight_len - 1;
+            let mut edited_bytes = vec![0; output_dim * std::mem::size_of::<i32>() + weight_len];
+            edited_bytes[output_dim * std::mem::size_of::<i32>() + file_index] = 19;
+            let edited =
+                DynamicAffine::read(&mut std::io::Cursor::new(edited_bytes), input_dim, output_dim)
+                    .expect("edited affine");
+
+            let mut delta = DynamicAffine::read(
+                &mut std::io::Cursor::new(vec![
+                    0;
+                    output_dim * std::mem::size_of::<i32>() + weight_len
+                ]),
+                input_dim,
+                output_dim,
+            )
+            .expect("base affine");
+            assert!(!delta.apply_file_weight_delta(file_index, 19));
+            assert_eq!(&*delta.biases, &*edited.biases);
+            assert_eq!(&*delta.weights, &*edited.weights);
+
+            delta.weights[file_index] = i8::MAX;
+            assert!(delta.apply_file_weight_delta(file_index, 1));
+            assert_eq!(delta.file_weight(file_index), i8::MAX);
         }
     }
 
@@ -667,6 +722,23 @@ mod tests {
             fv_scale: FV_SCALE,
             qa: 127,
         }
+    }
+
+    #[test]
+    fn net_delta_rejects_dynamic_halfkx() {
+        let spec = ArchitectureSpec::new(FeatureSet::HalfKP, 32, 4, 2, Activation::CReLU);
+        let mut network = NNUENetwork::DynamicHalfKx(Box::new(test_network(spec)));
+        let error = network
+            .apply_net_deltas(&[NetDelta {
+                id: NetCoefficientId {
+                    kind: NetTensorKind::FtBias,
+                    bucket: None,
+                    index: 0,
+                },
+                delta: 1,
+            }])
+            .expect_err("HalfKX must reject net deltas");
+        assert!(error.to_string().contains("unsupported architecture"));
     }
 
     #[test]

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -23,6 +23,7 @@ use super::ls_feature_spec::{
     HalfKaHmMergedSpec, HalfKaHmSplitSpec, HalfKaMergedSpec, HalfKaSplitSpec, HalfKpSpec,
     LsFeatureSpec,
 };
+use super::net_delta::{NetCoefficientId, NetTensorKind, NetTensorShape, add_i16_delta};
 use super::network::{
     LayerStackBucketMode, compute_layer_stack_progresskpabs_bucket_index, get_fv_scale_override,
     get_layer_stack_bucket_mode, get_layer_stack_progress_buckets,
@@ -375,6 +376,62 @@ impl DynamicLayerStacksNetwork {
     pub(crate) fn num_buckets(&self) -> usize {
         self.num_buckets
     }
+
+    pub(crate) fn net_tensor_shape(&self, kind: NetTensorKind) -> NetTensorShape {
+        match kind {
+            NetTensorKind::OutputWeight => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: self.buckets[0].output.weight_len(),
+            },
+            NetTensorKind::OutputBias => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: 1,
+            },
+            NetTensorKind::FtBias => NetTensorShape {
+                bucket_count: None,
+                element_count: self.ft_biases.len(),
+            },
+            NetTensorKind::L2Weight => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: self.buckets[0].l2.weight_len(),
+            },
+        }
+    }
+
+    pub(crate) fn net_coefficient(&self, id: &NetCoefficientId) -> i32 {
+        match id.kind {
+            NetTensorKind::OutputWeight => i32::from(
+                self.buckets[id.bucket.expect("validated bucket")].output.file_weight(id.index),
+            ),
+            NetTensorKind::OutputBias => {
+                self.buckets[id.bucket.expect("validated bucket")].output.bias(0)
+            }
+            NetTensorKind::FtBias => i32::from(self.ft_biases[id.index]),
+            NetTensorKind::L2Weight => i32::from(
+                self.buckets[id.bucket.expect("validated bucket")].l2.file_weight(id.index),
+            ),
+        }
+    }
+
+    pub(crate) fn apply_net_delta(&mut self, id: &NetCoefficientId, delta: i32) -> bool {
+        match id.kind {
+            NetTensorKind::OutputWeight => self.buckets[id.bucket.expect("validated bucket")]
+                .output
+                .apply_file_weight_delta(id.index, delta),
+            NetTensorKind::OutputBias => self.buckets[id.bucket.expect("validated bucket")]
+                .output
+                .apply_bias_delta(0, delta),
+            NetTensorKind::FtBias => {
+                let (value, clamped) = add_i16_delta(self.ft_biases[id.index], delta);
+                self.ft_biases[id.index] = value;
+                clamped
+            }
+            NetTensorKind::L2Weight => self.buckets[id.bucket.expect("validated bucket")]
+                .l2
+                .apply_file_weight_delta(id.index, delta),
+        }
+    }
+
     pub(crate) fn requires_board_effects(&self) -> bool {
         matches!(self.feature, RuntimeLsFeature::EffectBucket(_))
     }
@@ -1364,6 +1421,7 @@ mod tests {
     use super::*;
     use crate::nnue::accumulator_stack_variant::AccumulatorStackVariant;
     use crate::nnue::evaluator::NNUEEvaluator;
+    use crate::nnue::net_delta::{NetCoefficientId, NetDelta, NetTensorKind};
     use crate::nnue::network::NNUENetwork;
     #[cfg(feature = "layerstack-arch")]
     use crate::nnue::network::set_layer_stack_bucket_mode;
@@ -1398,6 +1456,180 @@ mod tests {
     fn zero_affine(input_dim: usize, output_dim: usize) -> DynamicAffine {
         let bytes = vec![0; output_dim * 4 + output_dim * padded_input(input_dim)];
         DynamicAffine::read(&mut Cursor::new(bytes), input_dim, output_dim).unwrap()
+    }
+
+    fn coefficient(kind: NetTensorKind, bucket: Option<usize>, index: usize) -> NetCoefficientId {
+        NetCoefficientId {
+            kind,
+            bucket,
+            index,
+        }
+    }
+
+    fn evaluated_values(
+        bytes: &[u8],
+        deltas: Option<&[NetDelta]>,
+        num_buckets: usize,
+    ) -> Vec<Value> {
+        let mut network = NNUENetwork::from_bytes(bytes).expect("synthetic LayerStacks");
+        if let Some(deltas) = deltas {
+            network.apply_net_deltas(deltas).expect("valid deltas");
+        }
+        crate::nnue::configure_layer_stack_routing(
+            LayerStackBucketMode::ProgressKPAbs,
+            num_buckets,
+            Some(num_buckets),
+        )
+        .expect("routing");
+
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).expect("hirate");
+        let mut evaluator = NNUEEvaluator::new_with_position(Arc::new(network), &pos);
+        let mut values = vec![evaluator.evaluate(&pos)];
+        for move_text in ["7g7f", "3c3d", "2g2f"] {
+            let mv = Move::from_usi(move_text).expect("move");
+            let gives_check = pos.gives_check(mv);
+            let dirty = pos.do_move(mv, gives_check);
+            evaluator.push(dirty);
+            values.push(evaluator.evaluate(&pos));
+        }
+        values
+    }
+
+    #[test]
+    fn dynamic_layer_stacks_net_delta_matches_file_edits_and_validates_shape() {
+        use crate::nnue::net_delta::test_utils::{
+            build_synthetic_layer_stacks, encode_single_byte_signed_leb128,
+        };
+
+        crate::nnue::reset_layer_stack_progress_kpabs_weights();
+
+        for num_buckets in [4, 9] {
+            let synthetic = build_synthetic_layer_stacks(
+                "HalfKP",
+                HalfKPFeatureSet::DIMENSIONS,
+                32,
+                4,
+                2,
+                num_buckets,
+            );
+            crate::nnue::configure_layer_stack_routing(
+                LayerStackBucketMode::ProgressKPAbs,
+                num_buckets,
+                Some(num_buckets),
+            )
+            .expect("routing");
+            let mut pos = Position::new();
+            pos.set_sfen(SFEN_HIRATE).expect("hirate");
+            let selected_bucket = compute_layer_stack_progresskpabs_bucket_index(
+                &pos,
+                pos.side_to_move(),
+                get_layer_stack_progress_kpabs_weights(),
+                num_buckets,
+            );
+            assert_eq!(selected_bucket, num_buckets / 2);
+
+            let baseline = evaluated_values(&synthetic.bytes, None, num_buckets);
+            let empty = evaluated_values(&synthetic.bytes, Some(&[]), num_buckets);
+            let zero = evaluated_values(
+                &synthetic.bytes,
+                Some(&[NetDelta {
+                    id: coefficient(NetTensorKind::FtBias, None, 0),
+                    delta: 0,
+                }]),
+                num_buckets,
+            );
+            assert_eq!(baseline, empty);
+            assert_eq!(baseline, zero);
+
+            let cases = [
+                (
+                    coefficient(NetTensorKind::OutputWeight, Some(selected_bucket), 0),
+                    synthetic.buckets[selected_bucket].output_weights,
+                    64,
+                ),
+                (
+                    coefficient(NetTensorKind::OutputBias, Some(selected_bucket), 0),
+                    synthetic.buckets[selected_bucket].output_bias,
+                    256,
+                ),
+                (coefficient(NetTensorKind::FtBias, None, 0), synthetic.ft_biases, 48),
+                (
+                    coefficient(NetTensorKind::L2Weight, Some(selected_bucket), 3),
+                    synthetic.buckets[selected_bucket].l2_weights + 3,
+                    64,
+                ),
+            ];
+            for (id, byte_offset, delta) in cases {
+                let network = NNUENetwork::from_bytes(&synthetic.bytes).expect("network");
+                let base = network.net_coefficient(&id).expect("coefficient");
+                let edited_value = base + delta;
+                let mut edited = synthetic.bytes.clone();
+                match id.kind {
+                    NetTensorKind::OutputBias => edited[byte_offset..byte_offset + 4]
+                        .copy_from_slice(&edited_value.to_le_bytes()),
+                    NetTensorKind::FtBias => {
+                        edited[byte_offset] = encode_single_byte_signed_leb128(edited_value);
+                    }
+                    NetTensorKind::OutputWeight | NetTensorKind::L2Weight => {
+                        edited[byte_offset] = edited_value as i8 as u8;
+                    }
+                }
+                let from_file = evaluated_values(&edited, None, num_buckets);
+                let from_delta = evaluated_values(
+                    &synthetic.bytes,
+                    Some(&[NetDelta {
+                        id: id.clone(),
+                        delta,
+                    }]),
+                    num_buckets,
+                );
+                assert_ne!(
+                    from_delta,
+                    baseline,
+                    "{}: baseline={baseline:?}, from_delta={from_delta:?}",
+                    id.usi_name()
+                );
+                assert_eq!(from_file, from_delta, "{}", id.usi_name());
+
+                let mut network = NNUENetwork::from_bytes(&synthetic.bytes).expect("network");
+                network
+                    .apply_net_deltas(&[NetDelta {
+                        id: id.clone(),
+                        delta,
+                    }])
+                    .expect("apply");
+                assert_eq!(network.net_coefficient(&id).expect("coefficient"), edited_value);
+            }
+
+            let mut network = NNUENetwork::from_bytes(&synthetic.bytes).expect("network");
+            let bad_bucket = NetDelta {
+                id: coefficient(NetTensorKind::OutputWeight, Some(num_buckets), 0),
+                delta: 1,
+            };
+            assert!(network.apply_net_deltas(&[bad_bucket]).is_err());
+            let out_w_len = network
+                .net_tensor_shape(NetTensorKind::OutputWeight)
+                .expect("shape")
+                .element_count;
+            let bad_index = NetDelta {
+                id: coefficient(NetTensorKind::OutputWeight, Some(0), out_w_len),
+                delta: 1,
+            };
+            assert!(network.apply_net_deltas(&[bad_index]).is_err());
+
+            let saturating_id = coefficient(NetTensorKind::OutputWeight, Some(0), 0);
+            let report = network
+                .apply_net_deltas(&[NetDelta {
+                    id: saturating_id.clone(),
+                    delta: 1_000,
+                }])
+                .expect("saturating delta");
+            assert_eq!(report.clamped, 1);
+            assert_eq!(network.net_coefficient(&saturating_id).expect("coefficient"), 127);
+        }
+        crate::nnue::reset_layer_stack_progress_buckets();
+        crate::nnue::reset_layer_stack_progress_kpabs_weights();
     }
 
     #[test]

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -301,6 +301,34 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             + i % Self::CHUNK_SIZE
     }
 
+    /// `.bin` の row-major flat index を実行時の格納 index に変換する。
+    #[inline]
+    pub(crate) const fn file_weight_index(i: usize) -> usize {
+        if Self::should_use_scrambled_weights() {
+            Self::get_weight_index_scrambled(i)
+        } else {
+            i
+        }
+    }
+
+    /// padding を含むファイル格納上の weight 要素数。
+    pub(crate) const fn weight_len() -> usize {
+        OUTPUT_DIM * Self::PADDED_INPUT
+    }
+
+    #[cfg(any(test, feature = "layerstack-arch"))]
+    pub(crate) fn file_weight(&self, index: usize) -> i8 {
+        self.weights[Self::file_weight_index(index)]
+    }
+
+    #[cfg(any(test, feature = "layerstack-arch"))]
+    pub(crate) fn apply_file_weight_delta(&mut self, index: usize, delta: i32) -> bool {
+        let memory_index = Self::file_weight_index(index);
+        let (value, clamped) = super::net_delta::add_i8_delta(self.weights[memory_index], delta);
+        self.weights[memory_index] = value;
+        clamped
+    }
+
     /// ゼロ初期化で新規作成
     pub fn new() -> Self {
         Self {
@@ -321,17 +349,13 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
         // 重みを読み込み（64バイトアラインで確保）
         // 格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
-        let weight_size = OUTPUT_DIM * Self::PADDED_INPUT;
+        let weight_size = Self::weight_len();
         let mut weights = AlignedBox::new_zeroed(weight_size);
         let mut buf1 = [0u8; 1];
 
         for i in 0..weight_size {
             reader.read_exact(&mut buf1)?;
-            let idx = if Self::should_use_scrambled_weights() {
-                Self::get_weight_index_scrambled(i)
-            } else {
-                i
-            };
+            let idx = Self::file_weight_index(i);
             weights[idx] = buf1[0] as i8;
         }
 
@@ -351,16 +375,12 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
         // 重みを読み込み（64バイトアラインで確保）
         // 格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
-        let weight_size = OUTPUT_DIM * Self::PADDED_INPUT;
+        let weight_size = Self::weight_len();
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
         for i in 0..weight_size {
             let val = read_signed_leb128(reader)?;
-            let idx = if Self::should_use_scrambled_weights() {
-                Self::get_weight_index_scrambled(i)
-            } else {
-                i
-            };
+            let idx = Self::file_weight_index(i);
             weights[idx] = val as i8;
         }
 
@@ -1053,6 +1073,55 @@ impl<const DIM: usize> ClippedReLU<DIM> {
 mod tests {
     use super::*;
     use crate::nnue::accumulator::Aligned;
+
+    fn affine_file_bytes<const INPUT: usize, const OUTPUT: usize>(weight: i8) -> Vec<u8> {
+        let mut bytes = vec![0; OUTPUT * std::mem::size_of::<i32>()];
+        bytes.extend(std::iter::repeat_n(
+            weight as u8,
+            AffineTransform::<INPUT, OUTPUT>::weight_len(),
+        ));
+        bytes
+    }
+
+    fn assert_file_edit_matches_delta<const INPUT: usize, const OUTPUT: usize>() {
+        let weight_len = AffineTransform::<INPUT, OUTPUT>::weight_len();
+        for (case, file_index) in [4, weight_len / 2 + 4, weight_len - 5].into_iter().enumerate() {
+            let value = 21 + case as u8;
+            let mut edited = affine_file_bytes::<INPUT, OUTPUT>(0);
+            edited[OUTPUT * std::mem::size_of::<i32>() + file_index] = value;
+            let edited = AffineTransform::<INPUT, OUTPUT>::read(&mut std::io::Cursor::new(edited))
+                .expect("edited affine");
+
+            let mut delta = AffineTransform::<INPUT, OUTPUT>::read(&mut std::io::Cursor::new(
+                affine_file_bytes::<INPUT, OUTPUT>(0),
+            ))
+            .expect("base affine");
+            assert!(!delta.apply_file_weight_delta(file_index, i32::from(value)));
+
+            assert_eq!(delta.biases, edited.biases);
+            assert_eq!(&*delta.weights, &*edited.weights);
+        }
+
+        if AffineTransform::<INPUT, OUTPUT>::should_use_scrambled_weights() {
+            assert_ne!(AffineTransform::<INPUT, OUTPUT>::file_weight_index(4), 4);
+        }
+    }
+
+    #[test]
+    fn file_order_delta_matches_affine_read_layouts() {
+        assert_file_edit_matches_delta::<30, 32>();
+        assert_file_edit_matches_delta::<32, 1>();
+    }
+
+    #[test]
+    fn affine_weight_delta_saturates() {
+        let mut affine = AffineTransform::<30, 32>::read(&mut std::io::Cursor::new(
+            affine_file_bytes::<30, 32>(127),
+        ))
+        .expect("affine");
+        assert!(affine.apply_file_weight_delta(17, 1));
+        assert_eq!(affine.file_weight(17), i8::MAX);
+    }
 
     #[test]
     fn test_affine_transform_propagate() {

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -55,6 +55,7 @@ mod leb128;
 mod ls_feature_spec;
 #[macro_use]
 pub mod macros;
+pub mod net_delta;
 mod network;
 pub(crate) mod network_halfka_hm_merged;
 pub(crate) mod network_halfka_hm_split;
@@ -111,6 +112,10 @@ pub use ls_feature_spec::{
     HalfKaHmMergedSpec, HalfKaHmSplitSpec, HalfKaMergedSpec, HalfKaSplitSpec, HalfKpSpec,
     LsFeatureSpec,
 };
+pub use net_delta::{
+    NET_DELTA_OPTION_PREFIX, NetCoefficientId, NetDelta, NetDeltaError, NetDeltaReport,
+    NetTensorKind, NetTensorShape,
+};
 #[cfg(feature = "layerstack-arch")]
 pub use network::evaluate_layer_stacks;
 pub(crate) use network::nnue_requires_board_effects;
@@ -122,8 +127,9 @@ pub use network::{
     configure_layer_stack_routing, detect_format, ensure_accumulator_computed, evaluate_dispatch,
     get_fv_scale_override, get_layer_stack_bucket_mode, get_layer_stack_progress_buckets,
     get_layer_stack_progress_kpabs_weights, get_network, init_nnue, init_nnue_from_bytes,
-    is_halfka_256_loaded, is_halfka_512_loaded, is_halfka_1024_loaded, is_halfka_hm_256_loaded,
-    is_halfka_hm_512_loaded, is_halfka_hm_1024_loaded, is_layer_stacks_loaded, is_nnue_initialized,
+    init_nnue_from_bytes_with_deltas, init_nnue_with_deltas, is_halfka_256_loaded,
+    is_halfka_512_loaded, is_halfka_1024_loaded, is_halfka_hm_256_loaded, is_halfka_hm_512_loaded,
+    is_halfka_hm_1024_loaded, is_layer_stacks_loaded, is_nnue_initialized,
     layer_stack_progress_coeff_required, load_progress_coeff_kpabs,
     load_progress_coeff_kpabs_from_bytes, parse_layer_stack_bucket_mode, parse_nnue_architecture,
     progress_sum_to_bucket, reset_layer_stack_progress_buckets,

--- a/crates/rshogi-core/src/nnue/net_delta.rs
+++ b/crates/rshogi-core/src/nnue/net_delta.rs
@@ -1,0 +1,419 @@
+//! 学習済み LayerStacks NNUE 係数への整数 delta。
+
+use std::fmt;
+
+/// net 係数を USI option として公開するときの接頭辞。
+pub const NET_DELTA_OPTION_PREFIX: &str = "SPSA_NET_";
+
+/// delta を適用できるテンソル種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NetTensorKind {
+    /// bucket ごとの output 層 weight (`i8`)。
+    OutputWeight,
+    /// bucket ごとの output 層 bias (`i32`)。
+    OutputBias,
+    /// Feature Transformer bias (`i16`)。
+    FtBias,
+    /// bucket ごとの第 2 FC 層 weight (`i8`)。
+    L2Weight,
+}
+
+impl NetTensorKind {
+    /// USI option 名で使う token を返す。
+    pub const fn token(self) -> &'static str {
+        match self {
+            Self::OutputWeight => "out_w",
+            Self::OutputBias => "out_b",
+            Self::FtBias => "ft_b",
+            Self::L2Weight => "l2_w",
+        }
+    }
+}
+
+/// net 内の係数を一意に表す ID。
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NetCoefficientId {
+    /// テンソル種別。
+    pub kind: NetTensorKind,
+    /// bucket を持つテンソルの bucket index。
+    pub bucket: Option<usize>,
+    /// `.bin` ファイル格納順の flat index。
+    pub index: usize,
+}
+
+impl NetCoefficientId {
+    /// `SPSA_NET_*` USI option 名を parse する。
+    pub fn parse_usi_name(name: &str) -> Option<Self> {
+        let body = name.strip_prefix(NET_DELTA_OPTION_PREFIX)?;
+        if let Some(index) = body.strip_prefix("ft_b_").and_then(parse_usize) {
+            return Some(Self {
+                kind: NetTensorKind::FtBias,
+                bucket: None,
+                index,
+            });
+        }
+
+        for (prefix, kind) in [
+            ("out_w_b", NetTensorKind::OutputWeight),
+            ("out_b_b", NetTensorKind::OutputBias),
+            ("l2_w_b", NetTensorKind::L2Weight),
+        ] {
+            let Some(indices) = body.strip_prefix(prefix) else {
+                continue;
+            };
+            let (bucket, index) = indices.split_once('_')?;
+            let bucket = parse_usize(bucket)?;
+            let index = parse_usize(index)?;
+            if kind == NetTensorKind::OutputBias && index != 0 {
+                return None;
+            }
+            return Some(Self {
+                kind,
+                bucket: Some(bucket),
+                index,
+            });
+        }
+        None
+    }
+
+    /// canonical な `SPSA_NET_*` USI option 名を返す。
+    pub fn usi_name(&self) -> String {
+        match self.bucket {
+            Some(bucket) => {
+                format!("{NET_DELTA_OPTION_PREFIX}{}_b{bucket}_{}", self.kind.token(), self.index)
+            }
+            None => format!("{NET_DELTA_OPTION_PREFIX}{}_{}", self.kind.token(), self.index),
+        }
+    }
+}
+
+fn parse_usize(value: &str) -> Option<usize> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse().ok()
+}
+
+/// 1 係数へ加える整数 delta。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetDelta {
+    /// 対象係数。
+    pub id: NetCoefficientId,
+    /// 現在値へ加える値。
+    pub delta: i32,
+}
+
+/// 1 種類のテンソル形状。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetTensorShape {
+    /// bucket を持つ場合の bucket 数。FT bias は `None`。
+    pub bucket_count: Option<usize>,
+    /// 1 bucket あたりの要素数。FT bias は配列全体の要素数。
+    pub element_count: usize,
+}
+
+impl NetTensorShape {
+    #[cfg(any(test, feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+    pub(crate) fn validate(self, id: &NetCoefficientId) -> Result<(), NetDeltaError> {
+        let name = id.usi_name();
+        match (self.bucket_count, id.bucket) {
+            (Some(bucket_count), Some(bucket)) if bucket >= bucket_count => {
+                return Err(NetDeltaError::BucketOutOfRange {
+                    name,
+                    bucket,
+                    bucket_count,
+                });
+            }
+            (Some(_), None) => return Err(NetDeltaError::MissingBucket { name }),
+            (None, Some(_)) => return Err(NetDeltaError::UnexpectedBucket { name }),
+            _ => {}
+        }
+        if id.index >= self.element_count {
+            return Err(NetDeltaError::IndexOutOfRange {
+                name,
+                index: id.index,
+                element_count: self.element_count,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// net delta 適用結果。
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct NetDeltaReport {
+    /// 適用した delta 数。
+    pub applied: usize,
+    /// 要素型の範囲へ clamp された delta 数。
+    pub clamped: usize,
+}
+
+/// net delta の検証・適用エラー。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetDeltaError {
+    /// LayerStacks 以外の architecture が指定された。
+    UnsupportedArchitecture {
+        /// 読み込まれている architecture 名。
+        architecture: String,
+    },
+    /// bucket 必須の kind に bucket が無い。
+    MissingBucket {
+        /// 問題の係数名。
+        name: String,
+    },
+    /// bucket を持たない kind に bucket が指定された。
+    UnexpectedBucket {
+        /// 問題の係数名。
+        name: String,
+    },
+    /// bucket index が範囲外。
+    BucketOutOfRange {
+        /// 問題の係数名。
+        name: String,
+        /// 指定された bucket index。
+        bucket: usize,
+        /// 読み込まれた net の bucket 数。
+        bucket_count: usize,
+    },
+    /// flat index が範囲外。
+    IndexOutOfRange {
+        /// 問題の係数名。
+        name: String,
+        /// 指定された flat index。
+        index: usize,
+        /// 対象テンソルの要素数。
+        element_count: usize,
+    },
+}
+
+impl fmt::Display for NetDeltaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedArchitecture { architecture } => {
+                write!(formatter, "unsupported architecture \"{architecture}\"")
+            }
+            Self::MissingBucket { name } => write!(formatter, "{name}: bucket is required"),
+            Self::UnexpectedBucket { name } => {
+                write!(formatter, "{name}: bucket is not allowed")
+            }
+            Self::BucketOutOfRange {
+                name,
+                bucket,
+                bucket_count,
+            } => write!(
+                formatter,
+                "{name}: bucket {bucket} is out of range (bucket count: {bucket_count})"
+            ),
+            Self::IndexOutOfRange {
+                name,
+                index,
+                element_count,
+            } => write!(
+                formatter,
+                "{name}: index {index} is out of range (element count: {element_count})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for NetDeltaError {}
+
+#[cfg(any(test, feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+pub(crate) fn add_i8_delta(value: i8, delta: i32) -> (i8, bool) {
+    let sum = i64::from(value) + i64::from(delta);
+    let clamped = sum.clamp(i64::from(i8::MIN), i64::from(i8::MAX));
+    (clamped as i8, sum != clamped)
+}
+
+#[cfg(any(test, feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+pub(crate) fn add_i16_delta(value: i16, delta: i32) -> (i16, bool) {
+    let sum = i64::from(value) + i64::from(delta);
+    let clamped = sum.clamp(i64::from(i16::MIN), i64::from(i16::MAX));
+    (clamped as i16, sum != clamped)
+}
+
+#[cfg(any(test, feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+pub(crate) fn add_i32_delta(value: i32, delta: i32) -> (i32, bool) {
+    let sum = i64::from(value) + i64::from(delta);
+    let clamped = sum.clamp(i64::from(i32::MIN), i64::from(i32::MAX));
+    (clamped as i32, sum != clamped)
+}
+
+#[cfg(all(
+    test,
+    any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch")
+))]
+pub(crate) mod test_utils {
+    use crate::nnue::constants::NNUE_VERSION_LAYERSTACK_NUM_BUCKETS;
+    use crate::nnue::layers::padded_input;
+    use crate::nnue::leb128::LEB128_MAGIC;
+
+    pub(crate) struct SyntheticBucketOffsets {
+        pub(crate) l2_weights: usize,
+        pub(crate) output_bias: usize,
+        pub(crate) output_weights: usize,
+    }
+
+    pub(crate) struct SyntheticLayerStacksBin {
+        pub(crate) bytes: Vec<u8>,
+        pub(crate) ft_biases: usize,
+        pub(crate) buckets: Vec<SyntheticBucketOffsets>,
+    }
+
+    struct Lcg(u32);
+
+    impl Lcg {
+        fn next(&mut self) -> u32 {
+            self.0 = self.0.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            self.0
+        }
+
+        fn range(&mut self, min: i32, max: i32) -> i32 {
+            min + (self.next() % ((max - min + 1) as u32)) as i32
+        }
+    }
+
+    pub(crate) fn encode_single_byte_signed_leb128(value: i32) -> u8 {
+        assert!((-64..=63).contains(&value));
+        (value as u8) & 0x7f
+    }
+
+    fn append_affine(
+        bytes: &mut Vec<u8>,
+        input_dim: usize,
+        output_dim: usize,
+        rng: &mut Lcg,
+        bias_range: std::ops::RangeInclusive<i32>,
+        weight_max: i32,
+    ) -> usize {
+        for _ in 0..output_dim {
+            let bias = rng.range(*bias_range.start(), *bias_range.end());
+            bytes.extend_from_slice(&bias.to_le_bytes());
+        }
+        let weights = bytes.len();
+        for _ in 0..output_dim * padded_input(input_dim) {
+            bytes.push(rng.range(1, weight_max) as u8);
+        }
+        weights
+    }
+
+    pub(crate) fn build_synthetic_layer_stacks(
+        feature_name: &str,
+        input_dimensions: usize,
+        l1: usize,
+        l2: usize,
+        l3: usize,
+        num_buckets: usize,
+    ) -> SyntheticLayerStacksBin {
+        let arch = format!(
+            "Features={feature_name}[{input_dimensions}->{l1}x2],LayerStacks,l2={l2},l3={l3}"
+        );
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&NNUE_VERSION_LAYERSTACK_NUM_BUCKETS.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&(arch.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(arch.as_bytes());
+        bytes.extend_from_slice(&(num_buckets as u32).to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+
+        let mut rng = Lcg(0x5eed_1234);
+        let ft_element_count = l1 + input_dimensions * l1;
+        bytes.extend_from_slice(LEB128_MAGIC);
+        bytes.extend_from_slice(&(ft_element_count as u32).to_le_bytes());
+        let ft_biases = bytes.len();
+        for _ in 0..l1 {
+            bytes.push(encode_single_byte_signed_leb128(rng.range(8, 15)));
+        }
+        for _ in l1..ft_element_count {
+            bytes.push(encode_single_byte_signed_leb128(rng.range(1, 2)));
+        }
+
+        let mut buckets = Vec::with_capacity(num_buckets);
+        for _ in 0..num_buckets {
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            append_affine(&mut bytes, l1, l2, &mut rng, 64..=127, 2);
+            let l2_weights = append_affine(&mut bytes, 2 * (l2 - 1), l3, &mut rng, 128..=255, 2);
+            let output_bias = bytes.len();
+            let output_weights = append_affine(&mut bytes, l3, 1, &mut rng, 128..=255, 8);
+            buckets.push(SyntheticBucketOffsets {
+                l2_weights,
+                output_bias,
+                output_weights,
+            });
+        }
+        SyntheticLayerStacksBin {
+            bytes,
+            ft_biases,
+            buckets,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integer_deltas_clamp_at_storage_bounds() {
+        assert_eq!(add_i8_delta(126, 1), (127, false));
+        assert_eq!(add_i8_delta(127, 1), (127, true));
+        assert_eq!(add_i16_delta(i16::MIN + 1, -1), (i16::MIN, false));
+        assert_eq!(add_i16_delta(i16::MIN, -1), (i16::MIN, true));
+        assert_eq!(add_i32_delta(i32::MAX - 1, 1), (i32::MAX, false));
+        assert_eq!(add_i32_delta(i32::MAX, 1), (i32::MAX, true));
+    }
+
+    #[test]
+    fn tensor_shape_validates_bucket_and_index() {
+        let shape = NetTensorShape {
+            bucket_count: Some(2),
+            element_count: 3,
+        };
+        let valid = NetCoefficientId {
+            kind: NetTensorKind::OutputWeight,
+            bucket: Some(1),
+            index: 2,
+        };
+        assert_eq!(shape.validate(&valid), Ok(()));
+
+        let mut invalid = valid.clone();
+        invalid.bucket = None;
+        assert!(matches!(shape.validate(&invalid), Err(NetDeltaError::MissingBucket { .. })));
+        invalid.bucket = Some(2);
+        assert!(matches!(shape.validate(&invalid), Err(NetDeltaError::BucketOutOfRange { .. })));
+        invalid.bucket = Some(1);
+        invalid.index = 3;
+        assert!(matches!(shape.validate(&invalid), Err(NetDeltaError::IndexOutOfRange { .. })));
+    }
+
+    #[test]
+    fn usi_name_round_trip() {
+        for name in [
+            "SPSA_NET_out_w_b3_17",
+            "SPSA_NET_out_b_b0_0",
+            "SPSA_NET_ft_b_1023",
+            "SPSA_NET_l2_w_b2_45",
+        ] {
+            let id = NetCoefficientId::parse_usi_name(name).expect("valid name");
+            assert_eq!(id.usi_name(), name);
+        }
+    }
+
+    #[test]
+    fn usi_name_rejects_invalid_forms() {
+        for name in [
+            "SPSA_out_w_b3_17",
+            "SPSA_NET_out_w_17",
+            "SPSA_NET_ft_b_b0_17",
+            "SPSA_NET_ft_b_",
+            "SPSA_NET_ft_b_-1",
+            "SPSA_NET_out_w_bx_17",
+            "SPSA_NET_out_w_b3_x",
+            "SPSA_NET_out_w_b3_17_extra",
+            "SPSA_NET_out_b_b0_1",
+            "SPSA_NET_unknown_b0_0",
+        ] {
+            assert!(NetCoefficientId::parse_usi_name(name).is_none(), "{name}");
+        }
+    }
+}

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -38,6 +38,9 @@ use super::halfka_hm_split::{HalfKaHmSplitNetwork, HalfKaHmSplitStack};
 use super::halfka_merged::{HalfKaMergedNetwork, HalfKaMergedStack};
 use super::halfka_split::{HalfKaSplitNetwork, HalfKaSplitStack};
 use super::halfkp::{HalfKPNetwork, HalfKPStack};
+use super::net_delta::{
+    NetCoefficientId, NetDelta, NetDeltaError, NetDeltaReport, NetTensorKind, NetTensorShape,
+};
 #[cfg(feature = "layerstack-arch")]
 use super::network_layer_stacks::LayerStacksNetwork;
 use super::spec::{Activation, FeatureSet};
@@ -436,6 +439,110 @@ impl NNUENetwork {
             return net.requires_board_effects();
         }
         cfg!(feature = "nnue-effect-bucket")
+    }
+
+    /// 読み込まれた net から対象テンソルの実行時形状を返す。
+    #[cfg(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+    pub fn net_tensor_shape(&self, kind: NetTensorKind) -> Result<NetTensorShape, NetDeltaError> {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if let Self::DynamicLayerStacks(net) = self {
+            return Ok(net.net_tensor_shape(kind));
+        }
+        #[cfg(feature = "layerstack-arch")]
+        if let Self::LayerStacks(net) = self {
+            return Ok(net.net_tensor_shape(kind));
+        }
+        Err(NetDeltaError::UnsupportedArchitecture {
+            architecture: self.architecture_name(),
+        })
+    }
+
+    /// 読み込まれた net から対象テンソルの実行時形状を返す。
+    #[cfg(not(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch")))]
+    pub fn net_tensor_shape(&self, kind: NetTensorKind) -> Result<NetTensorShape, NetDeltaError> {
+        match kind {
+            NetTensorKind::OutputWeight
+            | NetTensorKind::OutputBias
+            | NetTensorKind::FtBias
+            | NetTensorKind::L2Weight => Err(NetDeltaError::UnsupportedArchitecture {
+                architecture: self.architecture_name(),
+            }),
+        }
+    }
+
+    /// ファイル格納順 ID で指定した係数の現在値を返す。
+    #[cfg(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+    pub fn net_coefficient(&self, id: &NetCoefficientId) -> Result<i32, NetDeltaError> {
+        self.net_tensor_shape(id.kind)?.validate(id)?;
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if let Self::DynamicLayerStacks(net) = self {
+            return Ok(net.net_coefficient(id));
+        }
+        #[cfg(feature = "layerstack-arch")]
+        if let Self::LayerStacks(net) = self {
+            return Ok(net.net_coefficient(id));
+        }
+        unreachable!("net_tensor_shape rejected non-LayerStacks architecture")
+    }
+
+    /// ファイル格納順 ID で指定した係数の現在値を返す。
+    #[cfg(not(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch")))]
+    pub fn net_coefficient(&self, id: &NetCoefficientId) -> Result<i32, NetDeltaError> {
+        match id.kind {
+            NetTensorKind::OutputWeight
+            | NetTensorKind::OutputBias
+            | NetTensorKind::FtBias
+            | NetTensorKind::L2Weight => Err(NetDeltaError::UnsupportedArchitecture {
+                architecture: self.architecture_name(),
+            }),
+        }
+    }
+
+    /// LayerStacks net の係数へ整数 delta を 1 回適用する。
+    ///
+    /// すべての ID を先に検証するため、エラー時は net を変更しない。
+    #[cfg(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch"))]
+    pub fn apply_net_deltas(
+        &mut self,
+        deltas: &[NetDelta],
+    ) -> Result<NetDeltaReport, NetDeltaError> {
+        if deltas.is_empty() {
+            return Ok(NetDeltaReport::default());
+        }
+        for delta in deltas {
+            self.net_coefficient(&delta.id)?;
+        }
+
+        let mut report = NetDeltaReport {
+            applied: deltas.len(),
+            clamped: 0,
+        };
+        for delta in deltas {
+            let clamped = match self {
+                #[cfg(feature = "nnue-runtime-dimensions")]
+                Self::DynamicLayerStacks(net) => net.apply_net_delta(&delta.id, delta.delta),
+                #[cfg(feature = "layerstack-arch")]
+                Self::LayerStacks(net) => net.apply_net_delta(&delta.id, delta.delta),
+                _ => unreachable!("all deltas were validated against a LayerStacks network"),
+            };
+            report.clamped += usize::from(clamped);
+        }
+        Ok(report)
+    }
+
+    /// LayerStacks net の係数へ整数 delta を 1 回適用する。
+    #[cfg(not(any(feature = "nnue-runtime-dimensions", feature = "layerstack-arch")))]
+    pub fn apply_net_deltas(
+        &mut self,
+        deltas: &[NetDelta],
+    ) -> Result<NetDeltaReport, NetDeltaError> {
+        if deltas.is_empty() {
+            Ok(NetDeltaReport::default())
+        } else {
+            Err(NetDeltaError::UnsupportedArchitecture {
+                architecture: self.architecture_name(),
+            })
+        }
     }
 
     /// HalfKP でサポートされているアーキテクチャ一覧
@@ -1254,20 +1361,44 @@ pub fn progress_sum_to_bucket(sum: f32, num_buckets: usize) -> usize {
 
 /// NNUEを初期化（バージョン自動判別）
 pub fn init_nnue<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    let network = Arc::new(NNUENetwork::load(path)?);
+    init_nnue_with_deltas(path, &[]).map(|_| ())
+}
+
+/// NNUE をロードし、`Arc` で公開する前に整数 delta を適用する。
+pub fn init_nnue_with_deltas<P: AsRef<Path>>(
+    path: P,
+    deltas: &[NetDelta],
+) -> io::Result<NetDeltaReport> {
+    let mut network = NNUENetwork::load(path)?;
+    let report = network.apply_net_deltas(deltas).map_err(net_delta_io_error)?;
+    let network = Arc::new(network);
     NNUE_REQUIRES_BOARD_EFFECTS.store(network.requires_board_effects(), Ordering::Release);
     *NETWORK.write().expect("NNUE lock poisoned") = Some(network);
     NNUE_INITIALIZED.store(true, Ordering::Release);
-    Ok(())
+    Ok(report)
 }
 
 /// バイト列からNNUEを初期化（バージョン自動判別）
 pub fn init_nnue_from_bytes(bytes: &[u8]) -> io::Result<()> {
-    let network = Arc::new(NNUENetwork::from_bytes(bytes)?);
+    init_nnue_from_bytes_with_deltas(bytes, &[]).map(|_| ())
+}
+
+/// バイト列から NNUE をロードし、`Arc` で公開する前に整数 delta を適用する。
+pub fn init_nnue_from_bytes_with_deltas(
+    bytes: &[u8],
+    deltas: &[NetDelta],
+) -> io::Result<NetDeltaReport> {
+    let mut network = NNUENetwork::from_bytes(bytes)?;
+    let report = network.apply_net_deltas(deltas).map_err(net_delta_io_error)?;
+    let network = Arc::new(network);
     NNUE_REQUIRES_BOARD_EFFECTS.store(network.requires_board_effects(), Ordering::Release);
     *NETWORK.write().expect("NNUE lock poisoned") = Some(network);
     NNUE_INITIALIZED.store(true, Ordering::Release);
-    Ok(())
+    Ok(report)
+}
+
+fn net_delta_io_error(error: NetDeltaError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error)
 }
 
 /// グローバル NNUE をクリアする
@@ -2115,6 +2246,107 @@ mod tests {
     use super::*;
     use crate::nnue::constants::DEFAULT_NUM_BUCKETS;
     use crate::position::SFEN_HIRATE;
+
+    #[cfg(all(
+        feature = "layerstack-arch",
+        feature = "ft-halfka_hm_merged",
+        feature = "layerstacks-512x16x32",
+        not(feature = "nnue-psqt"),
+        not(feature = "nnue-threat"),
+        not(feature = "nnue-effect-bucket")
+    ))]
+    #[test]
+    fn const_generic_layer_stacks_applies_all_net_delta_kinds() {
+        use crate::nnue::constants::HALFKA_HM_DIMENSIONS;
+        use crate::nnue::evaluator::NNUEEvaluator;
+        use crate::nnue::net_delta::test_utils::build_synthetic_layer_stacks;
+        use crate::nnue::net_delta::{NetCoefficientId, NetDelta, NetTensorKind};
+
+        reset_layer_stack_progress_kpabs_weights();
+        configure_layer_stack_routing(LayerStackBucketMode::ProgressKPAbs, 4, Some(4))
+            .expect("routing");
+        let synthetic =
+            build_synthetic_layer_stacks("HalfKaHmMerged", HALFKA_HM_DIMENSIONS, 512, 16, 32, 4);
+        assert_eq!(synthetic.buckets.len(), 4);
+        assert!(synthetic.ft_biases < synthetic.buckets[0].l2_weights);
+        assert!(synthetic.buckets[0].l2_weights < synthetic.buckets[0].output_bias);
+        assert!(synthetic.buckets[0].output_bias < synthetic.buckets[0].output_weights);
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).expect("hirate");
+        let selected_bucket = compute_layer_stack_progresskpabs_bucket_index(
+            &pos,
+            pos.side_to_move(),
+            get_layer_stack_progress_kpabs_weights(),
+            4,
+        );
+        assert_eq!(selected_bucket, 2);
+
+        let evaluate = |deltas: &[NetDelta]| {
+            let mut network = NNUENetwork::from_bytes(&synthetic.bytes).expect("synthetic net");
+            network.apply_net_deltas(deltas).expect("apply deltas");
+            let mut evaluator = NNUEEvaluator::new_with_position(Arc::new(network), &pos);
+            evaluator.evaluate(&pos)
+        };
+        let baseline = evaluate(&[]);
+        let cases = [
+            (
+                NetCoefficientId {
+                    kind: NetTensorKind::OutputWeight,
+                    bucket: Some(selected_bucket),
+                    index: 0,
+                },
+                64,
+            ),
+            (
+                NetCoefficientId {
+                    kind: NetTensorKind::OutputBias,
+                    bucket: Some(selected_bucket),
+                    index: 0,
+                },
+                256,
+            ),
+            (
+                NetCoefficientId {
+                    kind: NetTensorKind::FtBias,
+                    bucket: None,
+                    index: 0,
+                },
+                48,
+            ),
+            (
+                NetCoefficientId {
+                    kind: NetTensorKind::L2Weight,
+                    bucket: Some(selected_bucket),
+                    index: 15,
+                },
+                64,
+            ),
+        ];
+        for (id, delta) in cases {
+            let base_network = NNUENetwork::from_bytes(&synthetic.bytes).expect("synthetic net");
+            let base = base_network.net_coefficient(&id).expect("coefficient");
+            let net_delta = NetDelta {
+                id: id.clone(),
+                delta,
+            };
+            let mut network = NNUENetwork::from_bytes(&synthetic.bytes).expect("synthetic net");
+            let report =
+                network.apply_net_deltas(std::slice::from_ref(&net_delta)).expect("apply delta");
+            assert_eq!(report.applied, 1);
+            assert_eq!(report.clamped, 0);
+            assert_eq!(network.net_coefficient(&id).expect("coefficient"), base + delta);
+
+            let from_delta = evaluate(&[net_delta]);
+            assert_ne!(
+                from_delta,
+                baseline,
+                "{}: baseline={baseline:?}, from_delta={from_delta:?}",
+                id.usi_name()
+            );
+        }
+        reset_layer_stack_progress_buckets();
+        reset_layer_stack_progress_kpabs_weights();
+    }
 
     /// NNUENetwork のアーキテクチャ自動検出テスト
     ///

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -2251,6 +2251,7 @@ mod tests {
         feature = "layerstack-arch",
         feature = "ft-halfka_hm_merged",
         feature = "layerstacks-512x16x32",
+        not(feature = "nnue-runtime-dimensions"),
         not(feature = "nnue-psqt"),
         not(feature = "nnue-threat"),
         not(feature = "nnue-effect-bucket")

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -25,6 +25,8 @@ use super::accumulator::Aligned;
 use super::accumulator_layer_stacks::{AccumulatorLayerStacks, AccumulatorStackLayerStacks};
 #[cfg(feature = "nnue-effect-bucket")]
 use super::constants::HALFKA_EFFECT_BUCKET_DIMENSIONS;
+#[cfg(feature = "layerstack-arch")]
+use super::constants::NNUE_PYTORCH_L3;
 use super::constants::{
     DEFAULT_NUM_BUCKETS, FV_SCALE_HALFKA, MAX_ARCH_LEN, MAX_LAYER_STACK_BUCKETS,
     NNUE_VERSION_HALFKA, NNUE_VERSION_LAYERSTACK_NUM_BUCKETS,
@@ -43,6 +45,8 @@ use super::constants::{LAYER_STACK_16X32_L1_OUT, LAYER_STACK_16X32_L2_IN};
 use super::constants::{LAYER_STACK_32X32_L1_OUT, LAYER_STACK_32X32_L2_IN};
 use super::feature_transformer_layer_stacks::FeatureTransformerLayerStacks;
 use super::layer_stacks::{LayerStacks, sqr_clipped_relu_transform};
+#[cfg(feature = "layerstack-arch")]
+use super::layers::AffineTransform;
 #[cfg(feature = "ft-halfka_hm_merged")]
 use super::ls_feature_spec::HalfKaHmMergedSpec;
 #[cfg(feature = "ft-halfka_hm_split")]
@@ -54,6 +58,10 @@ use super::ls_feature_spec::HalfKaSplitSpec;
 #[cfg(feature = "ft-halfkp")]
 use super::ls_feature_spec::HalfKpSpec;
 use super::ls_feature_spec::LsFeatureSpec;
+#[cfg(feature = "layerstack-arch")]
+use super::net_delta::{
+    NetCoefficientId, NetTensorKind, NetTensorShape, add_i16_delta, add_i32_delta,
+};
 use super::network::{
     LayerStackBucketMode, compute_layer_stack_progresskpabs_bucket_index, get_fv_scale_override,
     get_layer_stack_bucket_mode, get_layer_stack_progress_buckets,
@@ -535,6 +543,76 @@ impl<
     pub fn from_bytes(bytes: &[u8]) -> io::Result<Self> {
         let mut cursor = Cursor::new(bytes);
         Self::read(&mut cursor)
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_tensor_shape(&self, kind: NetTensorKind) -> NetTensorShape {
+        match kind {
+            NetTensorKind::OutputWeight => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: AffineTransform::<NNUE_PYTORCH_L3, 1>::weight_len(),
+            },
+            NetTensorKind::OutputBias => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: 1,
+            },
+            NetTensorKind::FtBias => NetTensorShape {
+                bucket_count: None,
+                element_count: L1,
+            },
+            NetTensorKind::L2Weight => NetTensorShape {
+                bucket_count: Some(self.num_buckets),
+                element_count: AffineTransform::<LS_L2_IN, NNUE_PYTORCH_L3>::weight_len(),
+            },
+        }
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_coefficient(&self, id: &NetCoefficientId) -> i32 {
+        match id.kind {
+            NetTensorKind::OutputWeight => i32::from(
+                self.layer_stacks.buckets[id.bucket.expect("validated bucket")]
+                    .output
+                    .file_weight(id.index),
+            ),
+            NetTensorKind::OutputBias => {
+                self.layer_stacks.buckets[id.bucket.expect("validated bucket")].output.biases[0]
+            }
+            NetTensorKind::FtBias => i32::from(self.feature_transformer.biases.0[id.index]),
+            NetTensorKind::L2Weight => i32::from(
+                self.layer_stacks.buckets[id.bucket.expect("validated bucket")]
+                    .l2
+                    .file_weight(id.index),
+            ),
+        }
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn apply_net_delta(&mut self, id: &NetCoefficientId, delta: i32) -> bool {
+        match id.kind {
+            NetTensorKind::OutputWeight => self.layer_stacks.buckets
+                [id.bucket.expect("validated bucket")]
+            .output
+            .apply_file_weight_delta(id.index, delta),
+            NetTensorKind::OutputBias => {
+                let bias = &mut self.layer_stacks.buckets[id.bucket.expect("validated bucket")]
+                    .output
+                    .biases[0];
+                let (value, clamped) = add_i32_delta(*bias, delta);
+                *bias = value;
+                clamped
+            }
+            NetTensorKind::FtBias => {
+                let bias = &mut self.feature_transformer.biases.0[id.index];
+                let (value, clamped) = add_i16_delta(*bias, delta);
+                *bias = value;
+                clamped
+            }
+            NetTensorKind::L2Weight => self.layer_stacks.buckets
+                [id.bucket.expect("validated bucket")]
+            .l2
+            .apply_file_weight_delta(id.index, delta),
+        }
     }
 
     /// 評価値を計算
@@ -1027,6 +1105,21 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
     /// 現在 load されている net の bucket 数 (= `.bin` header の `num_buckets`)
     pub fn num_buckets(&self) -> usize {
         ls_match_size!(self, net => net.num_buckets)
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_tensor_shape(&self, kind: NetTensorKind) -> NetTensorShape {
+        ls_match_size!(self, net => net.net_tensor_shape(kind))
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_coefficient(&self, id: &NetCoefficientId) -> i32 {
+        ls_match_size!(self, net => net.net_coefficient(id))
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn apply_net_delta(&mut self, id: &NetCoefficientId, delta: i32) -> bool {
+        ls_match_size!(self, net => net.apply_net_delta(id, delta))
     }
 
     /// (L1, L2, L3) と PSQT override から読み込み (FT は型レベルで固定)。
@@ -1866,6 +1959,21 @@ impl LayerStacksNetwork {
     /// 現在 load されている net の bucket 数 (= `.bin` header の `num_buckets`)
     pub fn num_buckets(&self) -> usize {
         ls_match_ft!(self, by_ft => by_ft.num_buckets())
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_tensor_shape(&self, kind: NetTensorKind) -> NetTensorShape {
+        ls_match_ft!(self, by_ft => by_ft.net_tensor_shape(kind))
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn net_coefficient(&self, id: &NetCoefficientId) -> i32 {
+        ls_match_ft!(self, by_ft => by_ft.net_coefficient(id))
+    }
+
+    #[cfg(feature = "layerstack-arch")]
+    pub(crate) fn apply_net_delta(&mut self, id: &NetCoefficientId, delta: i32) -> bool {
+        ls_match_ft!(self, by_ft => by_ft.apply_net_delta(id, delta))
     }
 
     /// アーキテクチャ仕様を取得

--- a/crates/rshogi-usi/README.md
+++ b/crates/rshogi-usi/README.md
@@ -39,6 +39,12 @@ The engine will start in USI mode, waiting for commands from stdin.
 | `USI_Hash` | Hash table size in MB | 256 |
 | `NetworkDelay` | Network delay compensation (ms) | 0 |
 | `NetworkDelay2` | Additional delay for uncertain situations | 0 |
+| `EvalFile` | NNUE model path | `eval/nn.bin` |
+| `SPSAParamsFile` | Search/net SPSA parameter file | `<auto>` |
+| `SPSA_NET_*` | LayerStacks net coefficient delta advertised by `--spsa-net-spec` | 0 |
+
+`SPSA_NET_*` options are loaded from the model again and applied at the next `isready`,
+`usinewgame`, or `go`; changing several options therefore causes one reload.
 
 ## License
 

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -2,20 +2,23 @@
 //!
 //! 将棋GUIとの通信を行うUSIプロトコル実装。
 
+use std::collections::BTreeMap;
 use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use rshogi_core::eval::{
     DEFAULT_PASS_RIGHT_VALUE_EARLY, DEFAULT_PASS_RIGHT_VALUE_LATE, MaterialLevel, disable_material,
     is_material_enabled, set_eval_hash_enabled, set_material_level, set_pass_move_bonus,
     set_pass_right_value_phased,
 };
 use rshogi_core::nnue::{
-    AccumulatorStackVariant, LayerStackBucketMode, MAX_LAYER_STACK_BUCKETS, clear_nnue,
-    configure_layer_stack_routing, evaluate_dispatch, get_network, init_nnue,
+    AccumulatorStackVariant, LayerStackBucketMode, MAX_LAYER_STACK_BUCKETS,
+    NET_DELTA_OPTION_PREFIX, NetCoefficientId, NetDelta, NetDeltaReport, clear_nnue,
+    configure_layer_stack_routing, evaluate_dispatch, get_network, init_nnue_with_deltas,
     layer_stack_progress_coeff_required, load_progress_coeff_kpabs, parse_layer_stack_bucket_mode,
     parse_nnue_architecture, print_nnue_stats, reset_layer_stack_progress_buckets,
     reset_layer_stack_progress_kpabs_weights, set_fv_scale_override,
@@ -86,6 +89,12 @@ struct UsiEngine {
     spsa_params_file: Option<String>,
     /// SPSA params ファイルの読み込み済みフラグ
     spsa_params_loaded: bool,
+    /// 起動時 spec から広告する net delta option 名。
+    spsa_net_spec_names: Vec<String>,
+    /// 現在設定されている net delta。
+    net_deltas: BTreeMap<NetCoefficientId, i32>,
+    /// ロード済み net へ未反映の delta があるか。
+    net_deltas_dirty: bool,
     /// Large Pages使用メッセージの出力済みフラグ
     large_pages_reported: bool,
     // --- 有限パス権（Finite Pass Rights）関連 ---
@@ -116,7 +125,12 @@ struct UsiEngine {
 
 impl UsiEngine {
     /// 新しいUSIエンジンを作成
+    #[cfg(test)]
     fn new() -> Self {
+        Self::new_with_spsa_net_spec(Vec::new())
+    }
+
+    fn new_with_spsa_net_spec(spsa_net_spec_names: Vec<String>) -> Self {
         let tt_size_mb = 256;
         let eval_hash_size_mb = 256;
         let use_eval_hash = true;
@@ -151,6 +165,9 @@ impl UsiEngine {
             ls_progress_coeff_loaded: false,
             spsa_params_file: None,
             spsa_params_loaded: false,
+            spsa_net_spec_names,
+            net_deltas: BTreeMap::new(),
+            net_deltas_dirty: false,
             large_pages_reported: false,
             pass_rights_enabled: false,
             initial_pass_count: 2,
@@ -179,13 +196,13 @@ impl UsiEngine {
                 self.cmd_usi();
             }
             "isready" => {
-                self.cmd_isready();
+                self.cmd_isready()?;
             }
             "setoption" => {
                 self.cmd_setoption(&tokens);
             }
             "usinewgame" => {
-                self.cmd_usinewgame();
+                self.cmd_usinewgame()?;
             }
             "position" => {
                 self.last_position_cmd = Some(line.to_string());
@@ -193,13 +210,13 @@ impl UsiEngine {
             }
             "go" => {
                 self.last_go_cmd = Some(line.to_string());
-                self.cmd_go(&tokens);
+                self.cmd_go(&tokens)?;
             }
             "stop" => {
                 self.cmd_stop();
             }
             "ponderhit" => {
-                self.cmd_ponderhit();
+                self.cmd_ponderhit()?;
             }
             "quit" => {
                 self.cmd_stop();
@@ -305,15 +322,20 @@ impl UsiEngine {
                 spec.usi_name, spec.default, spec.min, spec.max
             );
         }
+        for name in &self.spsa_net_spec_names {
+            println!("option name {name} type spin default 0 min -32768 max 32767");
+        }
         println!("usiok");
     }
 
     /// isreadyコマンド: 準備完了を通知
     /// YaneuraOu準拠: isready 受信時にTTをクリアする
-    fn cmd_isready(&mut self) {
+    fn cmd_isready(&mut self) -> Result<()> {
+        self.wait_for_search();
         if let Some(search) = self.search.as_mut() {
             search.clear_tt();
         }
+        self.maybe_load_spsa_params();
         // EvalFile の状態を確認し、必要なら NNUE をロード
         match self.eval_file_explicit {
             Some(false) => {
@@ -331,8 +353,9 @@ impl UsiEngine {
                 // EvalFile 未指定 + Material 未指定 + NNUE 未ロード → eval/nn.bin を自動ロード
                 const DEFAULT_EVAL_FILE: &str = "eval/nn.bin";
                 if std::path::Path::new(DEFAULT_EVAL_FILE).exists() {
-                    match init_nnue(DEFAULT_EVAL_FILE) {
-                        Ok(()) => {
+                    match self.load_nnue_with_current_deltas(Path::new(DEFAULT_EVAL_FILE)) {
+                        Ok(_) => {
+                            self.eval_file_path = Some(DEFAULT_EVAL_FILE.to_string());
                             let payload = json!({
                                 "type": "info",
                                 "message": format!("NNUE auto-loaded: {DEFAULT_EVAL_FILE}"),
@@ -355,6 +378,7 @@ impl UsiEngine {
                 // EvalFile 未指定だが Material 有効 or NNUE 既ロード → 何もしない
             }
         }
+        self.reload_net_deltas_if_dirty()?;
         // version は binary layout の判別にだけ使う。LayerStacks の routing semantics は
         // USI オプションと、ロード済み net の格納 bucket 数を突き合わせて検証する。
         if let Some(stored_bucket_count) =
@@ -387,10 +411,10 @@ impl UsiEngine {
                 routing_bucket_count
             );
         }
-        self.maybe_load_spsa_params();
         self.maybe_report_large_pages();
         self.maybe_load_book();
         println!("readyok");
+        Ok(())
     }
 
     /// 定跡ファイルのロード（isready 時に実施）。
@@ -493,7 +517,11 @@ impl UsiEngine {
                 }
             };
 
-            if let Some(search) = self.search.as_mut()
+            if name.starts_with(NET_DELTA_OPTION_PREFIX) {
+                if self.set_net_delta_value(name, parsed) {
+                    applied += 1;
+                }
+            } else if let Some(search) = self.search.as_mut()
                 && let Some(result) = search.set_search_tune_option(name, parsed)
             {
                 applied += 1;
@@ -511,6 +539,63 @@ impl UsiEngine {
                 clamped
             );
         }
+    }
+
+    fn set_net_delta_value(&mut self, name: &str, value: i32) -> bool {
+        let Some(id) = NetCoefficientId::parse_usi_name(name) else {
+            eprintln!("info string Warning: invalid SPSA net option name '{name}'");
+            return false;
+        };
+        let previous = self.net_deltas.get(&id).copied().unwrap_or(0);
+        if previous != value {
+            self.net_deltas.insert(id, value);
+            self.net_deltas_dirty = true;
+        }
+        true
+    }
+
+    fn current_net_deltas(&self) -> Vec<NetDelta> {
+        self.net_deltas
+            .iter()
+            .filter(|(_, delta)| **delta != 0)
+            .map(|(id, delta)| NetDelta {
+                id: id.clone(),
+                delta: *delta,
+            })
+            .collect()
+    }
+
+    fn load_nnue_with_current_deltas(&mut self, path: &Path) -> io::Result<NetDeltaReport> {
+        let deltas = self.current_net_deltas();
+        let report = init_nnue_with_deltas(path, &deltas)?;
+        if !deltas.is_empty() || self.net_deltas_dirty {
+            eprintln!(
+                "info string net deltas applied: {} coefficients (clamped: {})",
+                report.applied, report.clamped
+            );
+        }
+        self.net_deltas_dirty = false;
+        Ok(report)
+    }
+
+    fn reload_net_deltas_if_dirty(&mut self) -> Result<()> {
+        if !self.net_deltas_dirty || get_network().is_none() {
+            return Ok(());
+        }
+        // 探索 worker は global Arc の生存を前提に raw pointer を持つため、差し替え前に join する。
+        self.wait_for_search();
+        let path = self
+            .eval_file_path
+            .as_ref()
+            .map(PathBuf::from)
+            .context("NNUE delta reload requested, but the loaded EvalFile path is unknown")?;
+        self.load_nnue_with_current_deltas(&path)
+            .with_context(|| format!("failed to reload NNUE file {}", path.display()))?;
+        if let Some(search) = self.search.as_mut() {
+            search.clear_tt();
+            search.resize_eval_hash(self.eval_hash_size_mb);
+        }
+        Ok(())
     }
 
     fn maybe_report_large_pages(&mut self) {
@@ -573,6 +658,18 @@ impl UsiEngine {
         }
 
         // オプションを適用
+        if name.starts_with(NET_DELTA_OPTION_PREFIX) {
+            let parsed = match value.parse::<i32>() {
+                Ok(v) => v,
+                Err(_) => {
+                    eprintln!("info string Warning: invalid SPSA net value '{}'", value);
+                    return;
+                }
+            };
+            self.set_net_delta_value(&name, parsed);
+            return;
+        }
+
         if name.starts_with("SPSA_") {
             let parsed = match value.parse::<i32>() {
                 Ok(v) => v,
@@ -777,8 +874,8 @@ impl UsiEngine {
                 } else {
                     // パス指定: ロード試行し、結果を記録
                     self.eval_file_path = Some(value.to_string());
-                    match init_nnue(&value) {
-                        Ok(()) => {
+                    match self.load_nnue_with_current_deltas(Path::new(&value)) {
+                        Ok(_) => {
                             // 前 net 向けの routing 数を新 net に引き継がない。次の isready で
                             // 再検証・再設定されるまで LayerStacks 評価は loud に失敗する。
                             reset_layer_stack_progress_buckets();
@@ -826,10 +923,13 @@ impl UsiEngine {
                     // arch_str 不整合が原因でロード失敗していた場合、architecture override
                     // 変更後の再試行で成功する可能性がある。再試行しても失敗した場合は
                     // Some(false) のまま維持され、isready の panic 安全策は保持される。
-                    if let Some(ref path) = self.eval_file_path {
+                    // auto-load した path を明示指定済みの状態へ昇格させないために限定する。
+                    if self.eval_file_explicit.is_some()
+                        && let Some(path) = self.eval_file_path.clone()
+                    {
                         let was_loaded = get_network().is_some();
-                        match init_nnue(path) {
-                            Ok(()) => {
+                        match self.load_nnue_with_current_deltas(Path::new(&path)) {
+                            Ok(_) => {
                                 reset_layer_stack_progress_buckets();
                                 self.eval_file_explicit = Some(true);
                                 let action = if was_loaded {
@@ -1041,14 +1141,16 @@ impl UsiEngine {
     }
 
     /// usinewgameコマンド: 新しい対局の開始
-    fn cmd_usinewgame(&mut self) {
+    fn cmd_usinewgame(&mut self) -> Result<()> {
         self.cmd_stop();
+        self.reload_net_deltas_if_dirty()?;
 
         if let Some(search) = self.search.as_mut() {
             search.clear_tt();
             search.clear_histories(); // YaneuraOu準拠：履歴統計もクリア
         }
         self.position = Position::new();
+        Ok(())
     }
 
     /// positionコマンド: 局面設定
@@ -1173,11 +1275,12 @@ impl UsiEngine {
     }
 
     /// goコマンド: 探索開始
-    fn cmd_go(&mut self, tokens: &[&str]) {
+    fn cmd_go(&mut self, tokens: &[&str]) -> Result<()> {
         // 既存の探索を停止（bestmove出力を抑制する）
         // GUIがstopを送らずにposition+goを送ってきた場合、前のponder探索の
         // bestmoveがstdoutに出力されるとGUIが混乱する（YaneuraOu準拠）
         self.stop_search_silently();
+        self.reload_net_deltas_if_dirty()?;
 
         // 制限を解析
         let limits = self.parse_go_options(tokens);
@@ -1186,7 +1289,7 @@ impl UsiEngine {
         // go infinite / go mate / go ponder では probe しない（Phase 1 の単純化、設計メモ §3）。
         // book hit 時は探索スレッドを起こさず bestmove を直接出力する。
         if !limits.infinite && limits.mate == 0 && !limits.ponder && self.try_book_probe() {
-            return;
+            return Ok(());
         }
 
         // Stochastic_Ponder では 1 手戻した局面から先読みする（YaneuraOu 準拠）
@@ -1253,6 +1356,7 @@ impl UsiEngine {
                 })
                 .expect("failed to spawn search thread"),
         );
+        Ok(())
     }
 
     /// 現在局面を定跡で probe し、hit したら bestmove を直接出力して true を返す。
@@ -1448,19 +1552,20 @@ impl UsiEngine {
     }
 
     /// ponderhitコマンド: 先読みヒットを通知
-    fn cmd_ponderhit(&mut self) {
+    fn cmd_ponderhit(&mut self) -> Result<()> {
         if self.stochastic_ponder {
-            self.restart_after_ponderhit();
-            return;
+            self.restart_after_ponderhit()?;
+            return Ok(());
         }
 
         if let Some(handle) = &self.ponderhit_handle {
             handle.signal();
         }
+        Ok(())
     }
 
     /// Stochastic_Ponder の ponderhit 後に通常探索へ切り替える
-    fn restart_after_ponderhit(&mut self) {
+    fn restart_after_ponderhit(&mut self) -> Result<()> {
         self.stop_search_silently();
 
         if let Some(line) = self.last_position_cmd.clone() {
@@ -1476,9 +1581,10 @@ impl UsiEngine {
                 .collect();
             let tokens: Vec<&str> = owned.iter().map(String::as_str).collect();
             if !tokens.is_empty() {
-                self.cmd_go(&tokens);
+                self.cmd_go(&tokens)?;
             }
         }
+        Ok(())
     }
 
     /// 探索スレッドの終了を待ち、Searchを取り戻す
@@ -1596,6 +1702,46 @@ fn validate_layer_stack_routing(
     }
 }
 
+fn parse_startup_args(args: impl IntoIterator<Item = String>) -> Result<Option<PathBuf>> {
+    let mut spec_path = None;
+    let mut args = args.into_iter();
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--spsa-net-spec" => {
+                if spec_path.is_some() {
+                    bail!("--spsa-net-spec may only be specified once");
+                }
+                let path = args.next().context("--spsa-net-spec requires a path")?;
+                spec_path = Some(PathBuf::from(path));
+            }
+            _ => bail!("unknown argument: {argument}"),
+        }
+    }
+    Ok(spec_path)
+}
+
+fn parse_spsa_net_spec(content: &str) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    for (line_index, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let without_comment = trimmed.split("//").next().unwrap_or(trimmed);
+        let usable = without_comment.replace("[[NOT USED]]", "");
+        let usable = usable.trim();
+        if usable.is_empty() {
+            continue;
+        }
+        let name = usable.split(',').next().unwrap_or("").trim();
+        if NetCoefficientId::parse_usi_name(name).is_none() {
+            bail!("invalid SPSA net spec at line {}: '{name}'", line_index + 1);
+        }
+        names.push(name.to_string());
+    }
+    Ok(names)
+}
+
 fn main() -> Result<()> {
     // ロガー初期化（標準エラー出力）
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -1605,7 +1751,17 @@ fn main() -> Result<()> {
     // ビットボードテーブルの初期化（ホットパスでの OnceLock atomic check 回避）
     rshogi_core::bitboard::init_bitboard_tables();
 
-    let mut engine = UsiEngine::new();
+    let spec_path = parse_startup_args(std::env::args().skip(1))?;
+    let spec_names = match spec_path {
+        Some(path) => {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read SPSA net spec {}", path.display()))?;
+            parse_spsa_net_spec(&content)
+                .with_context(|| format!("failed to parse SPSA net spec {}", path.display()))?
+        }
+        None => Vec::new(),
+    };
+    let mut engine = UsiEngine::new_with_spsa_net_spec(spec_names);
     let stdin = io::stdin();
 
     for line in stdin.lock().lines() {
@@ -1628,6 +1784,64 @@ mod tests {
     // 履歴統計の初期化がスタックを大量に消費するため、別スレッドで実行
     // UsiEngine::new() が NNUE グローバル状態に依存するため、全テストを #[serial] で逐次実行
     const STACK_SIZE: usize = 64 * 1024 * 1024;
+
+    #[test]
+    fn spsa_net_spec_accepts_names_and_params_rows() {
+        let content = r#"
+# comment
+SPSA_NET_out_w_b3_17
+SPSA_NET_out_b_b0_0,int,0,-10,10,1,0.1 // output bias
+SPSA_NET_ft_b_1023,int,0,-10,10,1,0.1 [[NOT USED]]
+// ignored
+"#;
+        assert_eq!(
+            parse_spsa_net_spec(content).expect("spec"),
+            [
+                "SPSA_NET_out_w_b3_17",
+                "SPSA_NET_out_b_b0_0",
+                "SPSA_NET_ft_b_1023"
+            ]
+        );
+    }
+
+    #[test]
+    fn spsa_net_spec_reports_invalid_line_and_name() {
+        let error = parse_spsa_net_spec("# ok\nSPSA_NET_out_w_17,int,0").expect_err("invalid name");
+        let message = error.to_string();
+        assert!(message.contains("line 2"), "{message}");
+        assert!(message.contains("SPSA_NET_out_w_17"), "{message}");
+    }
+
+    #[test]
+    #[serial]
+    fn setoption_net_delta_saves_value_and_tracks_dirty_state() {
+        std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(|| {
+                let mut engine = UsiEngine::new();
+                let name = "SPSA_NET_l2_w_b2_45";
+                let id = NetCoefficientId::parse_usi_name(name).expect("id");
+
+                engine.cmd_setoption(&["setoption", "name", name, "value", "12"]);
+                assert_eq!(engine.net_deltas.get(&id), Some(&12));
+                assert!(engine.net_deltas_dirty);
+
+                engine.net_deltas_dirty = false;
+                engine.cmd_setoption(&["setoption", "name", name, "value", "12"]);
+                assert!(!engine.net_deltas_dirty);
+
+                engine.cmd_setoption(&["setoption", "name", name, "value", "0"]);
+                assert_eq!(engine.net_deltas.get(&id), Some(&0));
+                assert!(engine.net_deltas_dirty);
+
+                engine.net_deltas_dirty = false;
+                engine.cmd_setoption(&["setoption", "name", "SPSA_NET_out_w_3", "value", "1"]);
+                assert!(!engine.net_deltas_dirty);
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
 
     #[test]
     #[serial]

--- a/crates/tools/docs/spsa_runbook.md
+++ b/crates/tools/docs/spsa_runbook.md
@@ -1264,7 +1264,38 @@ ln -snf ../../rshogi-notes/spsa/<name>.rshogi.params <rshogi>/spsa_params/
   `tune_params.rs` の default に焼き込み済み（rebuild 経路）。ファイル投入経路で
   上書きすると二重適用ではなく **ファイル側が勝つ**（setoption は default を上書き）。
 
-## 12. トラブルシューティング
+## 12. net 重み SPSA (post-training)
+
+LayerStacks 系 NNUE の一部係数は、`.bin` 自体を書き換えず整数 delta として調整できる。
+調整対象の `.params` を engine 起動時の spec にも渡す。`--engine-args` は各 argv を
+個別指定するため、先頭が `-` の引数を含めて次の形で渡す。
+
+```bash
+cargo run --release -p tools --bin spsa -- \
+  --run-dir runs/spsa/net-example \
+  --init-from /path/to/net.params \
+  --total-pairs 6400 \
+  --engine-args=--spsa-net-spec \
+  --engine-args=/path/to/net.params \
+  --usi-option EvalFile=/path/to/layerstacks.bin
+```
+
+option 名は FC weight の padding を含む `.bin` 格納順 flat index を使う。bucket ありは
+`SPSA_NET_<kind>_b<bucket>_<index>`、bucket なしは
+`SPSA_NET_ft_b_<index>` とする。
+
+| kind | 対象 | bucket |
+|---|---|---|
+| `out_w` | output 層 weight (`i8`) | あり |
+| `out_b` | output 層 bias (`i32`, index は `0`) | あり |
+| `ft_b` | Feature Transformer bias (`i16`) | なし |
+| `l2_w` | 第 2 FC 層 weight (`i8`) | あり |
+
+`setoption` は delta を保存するだけで、続く `isready` で元の `EvalFile` を再ロードして
+全 delta を 1 回適用する。同じ値の再送では再ロードしない。係数候補を生成するツールと、
+確定 delta を net へ反映する finalize ツールは後続対応とする。
+
+## 13. トラブルシューティング
 
 実機での typical な詰まりどころと対処（症状ベース）。
 

--- a/scripts/profile_memset_callers.sh
+++ b/scripts/profile_memset_callers.sh
@@ -32,7 +32,8 @@ RUSTFLAGS="-C target-cpu=native" cargo build --release -p rshogi-usi 2>/dev/null
 # プロファイル取得（コールグラフ付き）
 echo "プロファイル取得中 (depth $DEPTH)..."
 sudo perf record -g --call-graph dwarf -o "$PERF_DATA" \
-  ./target/release/rshogi-usi --eval "$NNUE_FILE" <<EOF
+  ./target/release/rshogi-usi <<EOF
+setoption name EvalFile value $NNUE_FILE
 isready
 position startpos
 go depth $DEPTH


### PR DESCRIPTION
## Summary

- 学習済み LayerStacks net の 4 テンソル (出力層 weight `out_w` / 出力層 bias `out_b` / FT bias `ft_b` / 第 2 FC weight `l2_w`) に `(kind, bucket, index) → 整数 delta` を .bin ロード直後に 1 回だけ適用する経路を追加。既存 SPSA ドライバ (`spsa.rs`) が `.params` → `setoption` で駆動できるよう、係数を `SPSA_NET_<kind>_b<bucket>_<idx>` / `SPSA_NET_ft_b_<idx>` の USI option として露出する
- 形状 (bucket 数・要素数) はロードした net から実行時導出。const-generic / dynamic 両 LayerStacks 経路対応、非 LayerStacks arch と範囲外 index は明示エラー。index は .bin 格納順 flat index (FC は padding 込み `out*padded_in+in`)、const-generic 経路は `AffineTransform::read` と同じスクランブル写像を通す
- engine 起動引数 `--spsa-net-spec <file>` で option 名を `usi` 応答に広告 (spsa.rs は未広告 option を黙ってスキップするため)。setoption は保存 + dirty のみで、`isready` / `usinewgame` / `go` で探索 join 後に元 EvalFile を再ロードして適用 (batch 内は同値再送で再ロードなし)

## 設計判断

| 項目 | 選択 | 理由 |
|---|---|---|
| option 値の意味 | delta (初期値 0) | usi 時点では net 未ロードで現在値が分からない。delta=0 ⇒ 従来と bit 一致 |
| 反映方法 | ファイル再ロード + 適用 | net は `Arc` で不変 (FT weights は shm 共有で DerefMut panic)。対象 4 種は非共有 blob |
| spec の渡し方 | argv `--spsa-net-spec` | `usi` 応答前に必要なので setoption 不可。spsa.rs の `--engine-args` で渡せる |
| 未知 argv | エラー | 従来は argv を無視していたが、黙殺より可視化を優先 (`scripts/profile_memset_callers.sh` の `--eval` は元々無効だった) |

## 計画・背景

- 計画: rshogi-notes `rshogi/plans/20260904_net_output_spsa.md` (PR1/3)
- 後続: PR2 = `.params` generator、PR3 = finalize (.bin への焼き込み)

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets -D warnings` / `cargo test --workspace` / `check-tracked-abs-paths.sh`
- [x] edition matrix: `edition-halfkx` (LS feature なし)、`edition-layerstacks-halfka_hm_merged-512x16x32-none` (const-generic) の clippy と `net_delta` テスト、tools `nnue-arch`、wasm build
- [x] 合成 net (非ゼロ擬似乱数、bucket 4 / 9) で「バイト列編集ロード == delta 適用」の評価値 bit 一致 (4 kind、`!= baseline` も検証)、zero-delta の bit 一致、範囲外・非対応 arch の Err、saturation
- [x] 層単位: const-generic スクランブル配置 (`<30,32>`) / 非スクランブル (`<32,1>`) / `DynamicAffine` の同値テスト
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ModapwbiG43GtgaTxWWSq3