### PR TITLE
fix(tools): spsa の .params 書き出しで [[NOT USED]] をコメントの手前に置く

### DIFF
--- a/crates/tools/docs/spsa_runbook.md
+++ b/crates/tools/docs/spsa_runbook.md
@@ -382,10 +382,11 @@ cargo run --release -p tools --bin spsa_stats_to_plot_csv -- \
 ### 方法2: `.params` ファイルに `[[NOT USED]]` マーカー
 
 永続的に除外したいパラメータに `[[NOT USED]]` を付加する。
+マーカーは 7 番目の値カラムの後、インラインコメント (`//`) の前に置く。
 
 ```
 SPSA_CORR_PCV_WEIGHT,int,9536,0,32768,163,1638.4
-SPSA_LMR_TABLE_COEFF,int,2809,1024,8192,35,358.4 [[NOT USED]]
+SPSA_LMR_TABLE_COEFF,int,2809,1024,8192,35,358.4 [[NOT USED]] //base=2809
 ```
 
 ### 推奨チューニング順序

--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -1876,12 +1876,13 @@ fn write_params(path: &Path, params: &[SpsaParam]) -> Result<()> {
                 "{},{},{},{},{},{},{}",
                 p.name, p.type_name, v_str, p.min, p.max, p.c_end, p.r_end
             );
+            if p.not_used {
+                line.push(' ');
+                line.push_str(PARAM_NOT_USED_MARKER);
+            }
             if !p.comment.is_empty() {
                 line.push_str(" //");
                 line.push_str(&p.comment);
-            }
-            if p.not_used {
-                line.push_str(PARAM_NOT_USED_MARKER);
             }
             writeln!(w, "{line}")?;
         }
@@ -3678,6 +3679,71 @@ mod tests {
             let s = name.to_string_lossy();
             assert!(!s.starts_with(".spsa_state_"), "tempfile leaked: {s}");
         }
+    }
+
+    #[test]
+    fn write_params_round_trips_not_used_and_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.params");
+        let params = vec![
+            SpsaParam {
+                name: "CommentNotUsed".into(),
+                type_name: "int".into(),
+                is_int: true,
+                value: 1.0,
+                min: 0.0,
+                max: 10.0,
+                c_end: 1.0,
+                r_end: 0.002,
+                comment: "base=1".into(),
+                not_used: true,
+            },
+            SpsaParam {
+                name: "NoCommentNotUsed".into(),
+                type_name: "int".into(),
+                is_int: true,
+                value: 2.0,
+                min: 0.0,
+                max: 10.0,
+                c_end: 1.0,
+                r_end: 0.002,
+                comment: String::new(),
+                not_used: true,
+            },
+            SpsaParam {
+                name: "CommentUsed".into(),
+                type_name: "int".into(),
+                is_int: true,
+                value: 3.0,
+                min: 0.0,
+                max: 10.0,
+                c_end: 1.0,
+                r_end: 0.002,
+                comment: "base=3".into(),
+                not_used: false,
+            },
+        ];
+
+        write_params(&path, &params).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            body,
+            "CommentNotUsed,int,1.000000,0,10,1,0.002 [[NOT USED]] //base=1\n\
+             NoCommentNotUsed,int,2.000000,0,10,1,0.002 [[NOT USED]]\n\
+             CommentUsed,int,3.000000,0,10,1,0.002 //base=3\n"
+        );
+
+        let reloaded = read_params(&path).unwrap();
+        assert_eq!(reloaded.len(), 3);
+        assert_eq!(reloaded[0].name, "CommentNotUsed");
+        assert!(reloaded[0].not_used);
+        assert_eq!(reloaded[0].comment, "base=1");
+        assert_eq!(reloaded[1].name, "NoCommentNotUsed");
+        assert!(reloaded[1].not_used);
+        assert!(reloaded[1].comment.is_empty());
+        assert_eq!(reloaded[2].name, "CommentUsed");
+        assert!(!reloaded[2].not_used);
+        assert_eq!(reloaded[2].comment, "base=3");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `spsa.rs` の `write_params` (state.params / final.params 共通) が `[[NOT USED]]` をインラインコメント (`//`) の後ろに書いていたため、`parse_param_line` (`//` より左でのみマーカー判定) が検出できず、コメント付き NOT USED 行が再読込で使用行に化けていた
- writer をマーカー → コメントの順 (`..., r_end [[NOT USED]] //comment`) に揃える。parser は無変更 (旧形式のマーカー末尾・コメント無し行も従来どおり読める)
- round-trip テスト 3 ケース (comment+not_used / not_used のみ / comment のみ) と runbook の形式説明を追加

注意: 修正前の spsa が書いた run dir 内の `state.params` / `final.params` で「コメント付き NOT USED 行」がある場合は、resume 前に手で並び替えが必要。

## 関連

- Closes #1031 (発見: #1029 のレビュー)

## Test plan

- [x] `cargo fmt --check` / `cargo clippy -p tools -D warnings` (default と `--no-default-features --features nnue-arch`) / `cargo test -p tools` / `check-tracked-abs-paths.sh` / `git diff --check`
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Fable) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ModapwbiG43GtgaTxWWSq3