### PR TITLE
fix(nnue): const-generic LayerStacks reader の EffectBucket 判定を共有 helper に統一し E4= alias を受理

### DIFF
--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -2255,6 +2255,67 @@ mod tests {
     use crate::nnue::constants::DEFAULT_NUM_BUCKETS;
     use crate::position::SFEN_HIRATE;
 
+    #[cfg(any(
+        feature = "nnue-runtime-dimensions",
+        all(
+            feature = "layerstack-arch",
+            feature = "nnue-effect-bucket",
+            feature = "layerstacks-512x16x32"
+        )
+    ))]
+    #[test]
+    fn effect_bucket_e4_alias_matches_canonical_header_evaluation() {
+        use crate::nnue::evaluator::NNUEEvaluator;
+        use crate::nnue::net_delta::test_utils::build_synthetic_layer_stacks;
+
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        const L1: usize = 2;
+        #[cfg(not(feature = "nnue-runtime-dimensions"))]
+        const L1: usize = 512;
+
+        fn replace_architecture(bytes: &mut Vec<u8>, architecture: &str) {
+            let original_len =
+                u32::from_le_bytes(bytes[8..12].try_into().expect("architecture size"));
+            let original_end = 12 + usize::try_from(original_len).expect("architecture length");
+            let replacement_len = u32::try_from(architecture.len()).expect("replacement length");
+            bytes.splice(
+                8..original_end,
+                replacement_len.to_le_bytes().into_iter().chain(architecture.bytes()),
+            );
+        }
+
+        fn evaluate(bytes: &[u8], pos: &Position) -> Value {
+            let network = NNUENetwork::from_bytes(bytes).expect("effect bucket network");
+            assert!(network.is_layer_stacks());
+            let mut evaluator = NNUEEvaluator::new_with_position(Arc::new(network), pos);
+            evaluator.evaluate(pos)
+        }
+
+        let routing_guard = crate::nnue::network::layer_stack_routing_test_guard();
+        let input_dimensions = crate::nnue::EffectBucketConfig::KINGFIXED_2X2.dimensions();
+        let synthetic =
+            build_synthetic_layer_stacks("HalfKaHmMerged", input_dimensions, L1, 16, 32, 1);
+        let mut bytes = synthetic.bytes;
+        configure_layer_stack_routing(LayerStackBucketMode::ProgressKPAbs, 1, Some(1))
+            .expect("routing");
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).expect("hirate");
+
+        let canonical_arch = format!(
+            "Features=HalfKaHmMerged[{input_dimensions}->{L1}x2],EffectBucket=2x2fixed,l2=16,l3=32"
+        );
+        replace_architecture(&mut bytes, &canonical_arch);
+        let canonical_value = evaluate(&bytes, &pos);
+
+        let alias_arch =
+            format!("Features=HalfKaHmMerged[{input_dimensions}->{L1}x2],E4=4xfixed,l2=16,l3=32");
+        replace_architecture(&mut bytes, &alias_arch);
+        assert_eq!(evaluate(&bytes, &pos), canonical_value);
+
+        reset_layer_stack_progress_buckets();
+        drop(routing_guard);
+    }
+
     #[cfg(all(
         feature = "layerstack-arch",
         feature = "ft-halfka_hm_merged",

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -306,20 +306,28 @@ impl<
 
         #[cfg(feature = "nnue-effect-bucket")]
         {
-            let model_config = parse_effect_bucket_config_from_arch(&arch_str).ok_or_else(|| {
+            let model_config = super::spec::parse_effect_bucket_config(&arch_str).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("effect bucket build requires EffectBucket= token in arch string: {arch_str}"),
+                    format!(
+                        "effect bucket build requires EffectBucket= or E4= token in arch string: {arch_str}"
+                    ),
                 )
             })?;
-            if model_config != (EFFECT_BUCKET_NB, EFFECT_BUCKET_KING_BUCKETED) {
+            if (model_config.nb, model_config.king_bucketed)
+                != (EFFECT_BUCKET_NB, EFFECT_BUCKET_KING_BUCKETED)
+            {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
                         "effect bucket config mismatch: model=({}x{}), engine=({}x{}). \
                          Use a model trained with the matching effect bucket config.",
-                        model_config.0,
-                        if model_config.1 { "bucketed" } else { "fixed" },
+                        model_config.nb,
+                        if model_config.king_bucketed {
+                            "bucketed"
+                        } else {
+                            "fixed"
+                        },
                         EFFECT_BUCKET_NB,
                         if EFFECT_BUCKET_KING_BUCKETED {
                             "bucketed"
@@ -348,7 +356,10 @@ impl<
             }
         }
         #[cfg(not(feature = "nnue-effect-bucket"))]
-        if arch_str.contains("EffectBucket=") {
+        if matches!(
+            super::spec::detect_layer_stacks_feature(&arch_str),
+            Ok(super::spec::FeatureSet::HalfKaHmMergedEffectBucket)
+        ) {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "effect bucket model requires nnue-effect-bucket feature",
@@ -2111,11 +2122,10 @@ impl LayerStacksNetwork {
 /// reader の現在位置から LayerStacks ヘッダの arch_str を peek し、FT を判別する。
 ///
 /// tatara emit 形式の arch_str は `Features=<FT>(Friend)[<dim>->1536x2],...` で、
-/// `Features=` 直後のキーワードを最優先で読み取る。PascalCase 形式と underscore
-/// 形式を同じ 5 FT に解決し、キーワードが無ければ汎用 `parse_feature_set_from_arch`
-/// (LayerStacks fallback 含む) に委譲する。FT が明示されていないモデルは
-/// `FeatureSet::LayerStacks` を返し、上位の `read_with_feature_set` で
-/// HalfKaHmMerged 互換扱いになる。明示された未知キーワードはエラーにする。
+/// 共有 helper が EffectBucket alias、`Features=` keyword、旧 header の substring を
+/// dynamic reader と同じ規則で判定する。明示された未知 keyword はエラーとし、
+/// keyword が無く FT を特定できない旧 header だけ `FeatureSet::LayerStacks` へ fallback
+/// して、上位の `read_with_feature_set` で HalfKaHmMerged 互換扱いにする。
 ///
 /// 読み取り後は `Seek::seek(SeekFrom::Start(original))` で reader 位置を巻き戻す。
 /// `BufReader<File>` 等の seekable reader では seek 時に内部 buffer が破棄・再同期される
@@ -2151,24 +2161,13 @@ fn peek_layer_stacks_feature_set<R: Read + Seek>(
 #[cfg(feature = "layerstack-arch")]
 fn detect_layer_stacks_feature_set(arch_str: &str) -> Result<super::spec::FeatureSet, String> {
     use super::spec::FeatureSet as Fs;
-    if arch_str.contains("EffectBucket=") {
-        return Ok(Fs::HalfKaHmMergedEffectBucket);
-    }
-    if let Some(feature) = super::spec::parse_layer_stacks_feature_set_keyword(arch_str)? {
-        return Ok(feature);
-    }
-    Ok(super::spec::parse_feature_set_from_arch(arch_str).unwrap_or(Fs::LayerStacks))
-}
-
-#[cfg(feature = "nnue-effect-bucket")]
-fn parse_effect_bucket_config_from_arch(arch_str: &str) -> Option<(usize, bool)> {
-    let token = arch_str.split(',').find_map(|part| part.strip_prefix("EffectBucket="))?;
-    match token {
-        "2x2fixed" => Some((4, false)),
-        "2x2bucketed" => Some((4, true)),
-        "3x3fixed" => Some((9, false)),
-        "3x3bucketed" => Some((9, true)),
-        _ => None,
+    match super::spec::detect_layer_stacks_feature(arch_str) {
+        Ok(feature) => Ok(feature),
+        Err(_) => {
+            // 明示 keyword の解析エラーを伝播し、keyword が無い旧 header だけ互換扱いする。
+            super::spec::parse_layer_stacks_feature_set_keyword(arch_str)?;
+            Ok(Fs::LayerStacks)
+        }
     }
 }
 
@@ -2520,6 +2519,14 @@ mod tests {
                 "Features=HalfKaHmMerged(Friend)[73305->1536x2],EffectBucket=2x2fixed,Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
                 Fs::HalfKaHmMergedEffectBucket,
             ),
+            (
+                "Features=HalfKaHmMerged(Friend)[293220->1536x2],E4=2x2fixed,Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaHmMergedEffectBucket,
+            ),
+            (
+                "Features=HalfKaHmMerged(Friend)[293220->1536x2],E4=4xfixed,Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaHmMergedEffectBucket,
+            ),
         ];
 
         for (arch_str, expected) in cases {
@@ -2531,22 +2538,66 @@ mod tests {
         }
     }
 
-    /// `Features=` keyword が無い場合のみ `LayerStacks` fallback に落ち、明示された
-    /// 未知 keyword は拒否することを確認する。
+    /// FT を特定できない旧 header との互換性のため `LayerStacks` fallback を維持する。
     #[cfg(feature = "layerstack-arch")]
     #[test]
     fn test_detect_feature_set_fallback() {
         use crate::nnue::spec::FeatureSet as Fs;
-        // Features= が無く LayerStacks キーワードがあるケース → fallback で LayerStacks
+        // FT 未指定の旧 header を HalfKaHmMerged 互換で読むため fallback を維持する。
         let got = detect_layer_stacks_feature_set("LayerStacks(...)").unwrap();
         assert_eq!(got, Fs::LayerStacks);
-        // 完全に未知 → fallback の unwrap_or で LayerStacks
+        // FT を特定できない旧 header も同じ互換経路で読む。
         let got = detect_layer_stacks_feature_set("unknown-arch-string").unwrap();
         assert_eq!(got, Fs::LayerStacks);
+        // dynamic reader と同じ substring 判定にし、旧 header でも dispatch を一致させる。
+        let got = detect_layer_stacks_feature_set("legacy-HalfKP").unwrap();
+        assert_eq!(got, Fs::HalfKP);
         let err = detect_layer_stacks_feature_set(
             "Features=UnknownHalfKaHmMerged(Friend)[73305->1536x2]",
         )
         .unwrap_err();
         assert!(err.contains("Unknown feature set keyword"));
+    }
+
+    #[cfg(all(
+        feature = "layerstack-arch",
+        feature = "layerstacks-512x16x32",
+        feature = "ft-halfka_hm_merged",
+        not(feature = "nnue-effect-bucket")
+    ))]
+    #[test]
+    fn read_with_feature_set_rejects_effect_bucket_alias_without_feature() {
+        use crate::nnue::spec::FeatureSet;
+
+        fn read_error(effect_bucket_token: &str) -> io::Error {
+            let arch = format!(
+                "Features=HalfKaHmMerged(Friend)[293220->512x2],{effect_bucket_token},l2=16,l3=32"
+            );
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&NNUE_VERSION_HALFKA.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&(arch.len() as u32).to_le_bytes());
+            bytes.extend_from_slice(arch.as_bytes());
+            let mut reader = Cursor::new(bytes);
+
+            // 強制された FT dispatch でも effect-bucket の互換性検査を素通りさせない。
+            match LayerStacksNetwork::read_with_feature_set(
+                &mut reader,
+                FeatureSet::HalfKaHmMerged,
+                512,
+                16,
+                32,
+                None,
+            ) {
+                Ok(_) => panic!("effect bucket model must be rejected"),
+                Err(err) => err,
+            }
+        }
+
+        let canonical = read_error("EffectBucket=2x2fixed");
+        let alias = read_error("E4=4xfixed");
+        assert_eq!(canonical.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(alias.kind(), canonical.kind());
+        assert_eq!(alias.to_string(), canonical.to_string());
     }
 }


### PR DESCRIPTION
## Summary

- const-generic LayerStacks reader (`network_layer_stacks.rs`) が独自の feature 判定 / effect config 解析 (`EffectBucket=` のみ) を持っていたため、`E4=` alias の net が effect-bucket edition で `effect bucket build requires EffectBucket= token` で拒否されていた。dynamic reader / `net_bin_layout` が使う spec.rs の共有 helper (`detect_layer_stacks_feature` / `parse_effect_bucket_config`) に切り替え、`E4=` (`4xfixed` 等の旧表記含む) を同じ判定で受理する。独自実装 `parse_effect_bucket_config_from_arch` は削除
- fallback 規律は維持: 明示された未知 keyword / HalfKA の次元欠落は Err を伝播し、keyword の無い旧 header だけ `LayerStacks` に fallback (既存テストの断定を維持)。共有 helper の substring 判定により `legacy-HalfKP` のような keyword 無し header は dynamic と同じく `HalfKP` になる (回帰テストで固定)
- 非 effect-bucket build の防衛判定も共有 helper に統一し、`EffectBucket=` と `E4=` を同じ `Unsupported` で拒否 (`read_with_feature_set` 直接経路のテスト付き)
- canonical header と `E4=` alias の合成 net で評価値が一致することを default (dynamic) と `edition-layerstacks-halfka_hm_merged_effect_bucket-512x16x32-2x2_kingfixed` (const-generic) の両方でテスト

## 関連

- Closes #1030 (発見: #1029 のレビュー)

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --workspace -D warnings` / clippy `edition-halfkx` / clippy effect-bucket 512x16x32-2x2_kingfixed / `check-tracked-abs-paths.sh` / `git diff --check`
- [x] `cargo test -p rshogi-core --lib nnue` (default 514 pass、effect-bucket edition 439 pass、非 effect-bucket 512 edition の network_layer_stacks 7 pass)
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Fable) APPROVE

備考: `edition-layerstacks-halfka_hm_merged-512x16x32-none` で `test_layer_stack_num_buckets_out_of_range_rejected` が失敗するのは main からの既存問題 (テストが 1536x16x32 net を前提)。CI matrix 外で本 PR とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ModapwbiG43GtgaTxWWSq3