### PR TITLE
rescore_psv: routing bucket 不一致の検出と --out-scores の NNUE 静的評価開放

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ core 変更を公開する PR では `crates/rshogi-core/Cargo.toml` のバー�
 
 ## Unreleased
 
+### rescore_psv: routing bucket 数の防御と NNUE score sidecar
+
+- `--ls-progress-buckets` が NNUE ファイルの格納 bucket 数と不一致の場合はエラーに
+  なる（合法設定として素通りし全行を無警告で誤評価にしていた）。格納数より少ない
+  routing で学習された旧世代 net の評価は新フラグ
+  `--allow-routing-buckets-mismatch` で警告付きに許可する。
+- `--out-scores`（i16 score sidecar）を NNUE 静的評価モードに開放した。dlshogi
+  ONNX 経路と同じ `.in-progress` / `.done` marker による中断再開・fail-closed
+  （エラーを含むチャンクは 1 byte も書かない）で、fingerprint は NNUE の
+  path/size/mtime と routing 設定（progress 係数は sha256）・FV_SCALE 変換を追跡する。
+
 ### 破壊的変更: LayerStacks routing の明示化
 
 - bucket mode 名 `progress8kpabs` を `progresskpabs` へ変更した。旧名の alias はなく、指定するとエラーになる。

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -34,7 +34,7 @@
 | `split_psv` | PSV ファイルを局面数または容量で分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおり結合 |
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](docs/relabel_psv.md)） |
-| `rescore_psv` | 局面の再評価（探索スコア付与） |
+| `rescore_psv` | 局面の再評価（NNUE / 外部エンジン / ONNX。`--out-scores` で i16 score sidecar 出力） |
 | `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
 | `psv_dual_label` | 通常 PSV の score 退避、dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順に抽出（[詳細](docs/psv_select_by_mask.md)） |
@@ -118,7 +118,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [generate_net_spsa_params](docs/generate_net_spsa_params.md) - LayerStacks `.bin` から net 重み delta 用 SPSA `.params` を生成
 - [apply_net_spsa_params](docs/apply_net_spsa_params.md) - net 重み SPSA の確定 delta を LayerStacks `.bin` へ焼き込み、feature 非依存で読み戻し検証する
-- [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
+- [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム / score sidecar（`--out-scores`、dlshogi ONNX と NNUE 静的評価）対応。LayerStacks routing は格納 bucket 数との不一致を拒否し、旧世代 net のみ `--allow-routing-buckets-mismatch` で明示許可）
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
 - [psv_dual_label](docs/psv_dual_label.md) - 通常 PSV の score 退避、dual-label PSV の生成・sidecar 抽出・fail-closed 検証
 - [psv_select_by_mask](docs/psv_select_by_mask.md) - bitmap mask の bit 1 に対応する PSV 行の順序保持抽出

--- a/crates/tools/docs/rescore_psv-internals.md
+++ b/crates/tools/docs/rescore_psv-internals.md
@@ -70,7 +70,8 @@ TensorRT FP32 は計測の結果 CUDA EP より遅い（カーネル最適化の
 
 ## 完了マーカー（`<rescore_output>.done`）の仕様
 
-ONNX モードで各入力ファイルの処理完了時に `key=value` 形式の sidecar テキストを
+ONNX モードと NNUE 静的評価 + `--out-scores` モードで、各入力ファイルの処理完了時に
+`key=value` 形式の sidecar テキストを
 atomic rename + `sync_all()` で書く。プロセス kill / panic に耐えるが、電源断・
 カーネルパニックは非目標。
 
@@ -98,11 +99,17 @@ fingerprint に含まれる項目:
   `--expand-output-dir` の canonicalize 済みパス
 - replacement 有効時: `--qsearch-leaf-replacement-output` の canonicalize 済みパス
   とその出力サイズ
+- NNUE 静的評価 + `--out-scores`（`mode=nnue-static`）時のみ: `--ls-bucket-mode` /
+  `--ls-progress-buckets` / `--ls-progress-coeff`（canonicalize 済みパス + sha256）、
+  `--source-fv-scale` / `--target-fv-scale`。このモードでは model キーが NNUE ファイル
+  を指し、ONNX 専用キー（`eval_scale_bits` / `onnx_draw_ply`）は固定値 0 を書く
 
 後方互換: 旧 marker の `use_tensorrt` キー欠落は unknown として読み、現在値の
 `true` / `false` のどちらとも fingerprint を一致させない。このためキー無し旧 marker は
 更新後の初回実行で出力を truncate して一度だけ再生成され、再生成後の marker には同キーが入る。
 `out_scores` キー欠落は従来どおり `false` 扱い（旧 sidecar 出力は存在しないため安全）。
+`nnue_*` キー欠落は `None` 扱いで、NNUE 静的評価の現設定とは fingerprint 不一致になり
+再生成される。
 旧 marker の `--qsearch-leaf-label` / `replacement` キー欠落も `false` 扱い。
 `--qsearch-leaf-label=true` だが
 葉探索 NNUE キーを持たない旧 marker は NNUE メタを `None` として読み、現設定と

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -142,7 +142,7 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 |---|---|---|
 | `--input` | （必須） | 入力 PSV。glob / 複数指定可 |
 | `--output-dir` | （必須） | 出力ディレクトリ（入力ファイル名で出力） |
-| `--out-scores` | false | dlshogi ONNX の score のみを `<入力名>.scores.i16` に出力（後述） |
+| `--out-scores` | false | dlshogi ONNX または NNUE 静的評価の score のみを `<入力名>.scores.i16` に出力（後述） |
 | `--threads` | 0（論理コア数） | 並列処理スレッド数 |
 | `--limit` | 0（無制限） | 各入力ファイルで処理するレコード数上限（`--out-scores` と併用不可） |
 | `--score-clip` | 10000 | スコアを ± この値にクリップ |
@@ -184,6 +184,7 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 | `--max-ply` | 16 | qsearch の最大深さ |
 | `--apply-qsearch-leaf` | false | 局面を qsearch 葉に置換して出力 |
 | `--source-fv-scale` / `--target-fv-scale` | 24 / 24 | FV_SCALE 変換（通常は変換不要） |
+| `--allow-routing-buckets-mismatch` | false | `--ls-progress-buckets` と格納 bucket 数の不一致を警告付きで許可（旧世代 net 専用、本文参照） |
 | `--engine` | — | 外部 USI エンジンパス。内部 NNUE の代わりに評価 |
 | `--engine-nodes` | 1 | エンジンの `go nodes` 値（0 で `go depth 1`） |
 | `--engine-threads` | 1 | 並列エンジンプロセス数（DL 系は VRAM に応じ 2〜4） |
@@ -231,18 +232,29 @@ rescore_psv --input "data/*.psv" --output-dir scores/ \
   --dlshogi-onnx-model model.onnx --out-scores
 ```
 
+```bash
+# NNUE 静的評価でも同じ sidecar を出力できる（LayerStacks は routing 3 オプション併用）
+rescore_psv --input "data/*.psv" --output-dir scores/ \
+  --nnue ls.bin --ls-bucket-mode progresskpabs --ls-progress-buckets 9 \
+  --ls-progress-coeff progress.bin --out-scores
+```
+
 フル PSV の代わりに `<入力ファイル名>.scores.i16` を生成する。record `i` の score は
 offset `i * 2` にある little-endian i16 で、ファイルサイズは厳密に
 `base PSV の全 records × 2` byte となる。通常のフル PSV
 出力と同じ推論・符号変換・clip を通り、
 通常出力の offset 32..34 を行順に抽出したものと bit 一致する。
 
-このモードは `--dlshogi-onnx-model` の直接推論専用で、NNUE、qsearch、search、外部
+このモードは `--dlshogi-onnx-model` の直接推論、または `--nnue` の静的評価
+（qsearch なし）で使える。qsearch、search、外部
 engine、AobaZero ONNX、leaf label/replacement、expand、入力を削除する `--delete-input`、
 処理件数を制限する `--limit`（0 より大きい値）、および行を減らす `--skip-in-check` とは
 併用できない。入力は 40 byte の倍数でなければ
 即時エラーになる。run 開始時に `<入力名>.scores.i16.in-progress` を作り、
-入力・ONNX モデル・ラベル条件の fingerprint を記録する。中断後はこの marker が現在の
+入力・モデル・ラベル条件の fingerprint を記録する（NNUE 静的評価では ONNX モデルの
+代わりに NNUE の path/size/mtime と routing 設定 `--ls-bucket-mode` /
+`--ls-progress-buckets` / `--ls-progress-coeff`（path + sha256）、
+`--source-fv-scale` / `--target-fv-scale` を追跡する）。中断後はこの marker が現在の
 設定と一致し、既存 sidecar が 2 byte の倍数であるときだけ、サイズを 2 で割った record
 位置から追記再開する。一致時に奇数 byte なら即時エラーになる。marker が無い、壊れている、
 または fingerprint が異なる場合は、既存サイズにかかわらず sidecar を truncate して最初から生成する。
@@ -315,9 +327,11 @@ rescore_psv --input "data/*.bin" --output-dir rescored_leaflabel/ \
 # 静的 NNUE 評価（CPU のみ、最軽量）
 rescore_psv --input data.bin --output-dir rescored/ --nnue nn.bin
 
-# LayerStacks progresskpabs（routing は必ず学習時と同じ値を明示）
+# LayerStacks progresskpabs（routing は必ず学習時と同じ値を明示。
+# 格納 bucket 数と不一致の指定はエラー。旧世代の格納 9 / routing 8 net だけ
+# --allow-routing-buckets-mismatch で通す）
 rescore_psv --input data.bin --output-dir rescored/ --nnue ls.bin \
-  --ls-bucket-mode progresskpabs --ls-progress-buckets 8 \
+  --ls-bucket-mode progresskpabs --ls-progress-buckets 9 \
   --ls-progress-coeff progress.bin
 
 # qsearch 評価
@@ -342,6 +356,11 @@ LayerStacks NNUE では `--ls-bucket-mode` が必須です。`progresskpabs` は
 `--ls-progress-buckets` と `--ls-progress-coeff` が必須で、格納 bucket 数を routing 数へ
 暗黙採用しません。`kingrank9` は progress 用の2オプションを指定せず、格納9 bucket のモデルだけを受理します。
 
+`--ls-progress-buckets` が NNUE ファイルの格納 bucket 数と異なる場合はエラーになります
+（誤った routing 数は全行を無警告で誤評価にするため）。格納 bucket 数より少ない routing で
+学習された旧世代 net（例: 格納 9 / routing 8）を意図的に評価する場合のみ
+`--allow-routing-buckets-mismatch` を付けると警告付きで通過します。
+
 ## 再開（resume）の仕組み
 
 - **ONNX モード**: 入力ファイルごとに完了マーカー `<出力名>.done` を書く。
@@ -357,6 +376,11 @@ LayerStacks NNUE では `--ls-bucket-mode` が必須です。`progresskpabs` は
   自身の mtime は fingerprint に含めないため、追記による mtime 更新は resume を妨げない。
   `Ctrl-C` 中断時は in-progress marker を残し、正常完了時だけ `.done` へ昇格する。
   同じ出力 sidecar への複数プロセスからの同時書き込みは非対応。
+- **NNUE 静的評価 + `--out-scores`**: ONNX の `--out-scores` と同じ
+  `.in-progress` / `.done` marker 方式で中断再開・skip 判定を行う。fingerprint は
+  入力 path/size/mtime、NNUE path/size/mtime、全入力件数、`--score-clip`、
+  routing（`--ls-bucket-mode` / `--ls-progress-buckets` / `--ls-progress-coeff` の
+  path + sha256）、`--source-fv-scale` / `--target-fv-scale` を追跡する。
 - **NNUE / 探索 / 外部エンジンモード**: マーカーは使わず、出力レコード数が入力
   レコード数以上のファイルを skip する（ファイル粒度。中途半端なファイルは最初
   から再処理）。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -56,7 +56,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `split_psv` | PSV ファイルを局面数または容量で複数ファイルへ分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](relabel_psv.md)） |
-| `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
+| `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム・score sidecar (`--out-scores`、dlshogi ONNX / NNUE 静的評価) 対応。LayerStacks routing の bucket 数不一致は拒否 (`--allow-routing-buckets-mismatch` で明示許可)（[詳細](rescore_psv.md)） |
 | `psv_gate_by_king_zone` | 入玉ドメインで base / override score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
 | `psv_dual_label` | 通常 PSV の score 退避、DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順にストリーミング抽出（[詳細](psv_select_by_mask.md)） |

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1480,7 +1480,55 @@ fn process_file_nnue_scores(
     progress: &FileProgress,
 ) -> Result<()> {
     const CHUNK_SIZE: usize = 1_000_000;
+    let max_ply = cli.max_ply;
+    let score_clip = cli.score_clip;
+    let source_fv_scale = cli.source_fv_scale;
+    let target_fv_scale = cli.target_fv_scale;
+    run_nnue_scores_pipeline(
+        cli,
+        input_path,
+        output_path,
+        process_count,
+        progress,
+        CHUNK_SIZE,
+        &|record| {
+            thread_local! {
+                static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
+            }
+            NNUE_STACKS.with(|stacks| {
+                let mut stacks = stacks.borrow_mut();
+                stacks.reset();
+                process_record(
+                    record,
+                    &mut stacks,
+                    max_ply,
+                    false,
+                    false,
+                    score_clip,
+                    false,
+                    source_fv_scale,
+                    target_fv_scale,
+                )
+            })
+        },
+    )
+}
+
+/// [`process_file_nnue_scores`] の本体。record 評価関数と chunk サイズを注入可能に
+/// して、NNUE ロードなし・小 chunk での統合テスト (順序保存 / chunk 境界 /
+/// fail-closed / resume) を成立させる。marker / resume / 件数検証のセマンティクスは
+/// この関数が単一の実装である。
+fn run_nnue_scores_pipeline(
+    cli: &Cli,
+    input_path: &PathBuf,
+    output_path: &PathBuf,
+    process_count: u64,
+    progress: &FileProgress,
+    chunk_size: usize,
+    eval_record: &(dyn Fn(&[u8; PackedSfenValue::SIZE]) -> ProcessResult + Sync),
+) -> Result<()> {
     const SCORE_RECORD_SIZE: u64 = 2;
+    assert!(chunk_size >= 1, "chunk_size must be >= 1");
 
     let start_fingerprint = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
     prepare_in_progress_marker(output_path, &start_fingerprint, false)?
@@ -1505,10 +1553,6 @@ fn process_file_nnue_scores(
         .with_context(|| format!("Failed to open {}", output_path.display()))?;
     let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
 
-    let max_ply = cli.max_ply;
-    let score_clip = cli.score_clip;
-    let source_fv_scale = cli.source_fv_scale;
-    let target_fv_scale = cli.target_fv_scale;
     let verbose = cli.verbose;
 
     progress.set_message("Processing...");
@@ -1525,7 +1569,7 @@ fn process_file_nnue_scores(
             break;
         }
 
-        let want = (CHUNK_SIZE as u64).min(process_count - total_written) as usize;
+        let want = (chunk_size as u64).min(process_count - total_written) as usize;
         let mut chunk: Vec<[u8; PackedSfenValue::SIZE]> = Vec::with_capacity(want);
         let mut buffer = [0u8; PackedSfenValue::SIZE];
         for _ in 0..want {
@@ -1542,29 +1586,7 @@ fn process_file_nnue_scores(
         // 行対応維持のためチャンク全件を評価してから一括書き出しする。process_file と
         // 違い INTERRUPTED での record 単位 early-out はしない (None 化した行が
         // fail-closed でエラー扱いになり、正常な中断がエラー終了に化けるため)。
-        let results: Vec<ProcessResult> = chunk
-            .par_iter()
-            .map(|record| {
-                thread_local! {
-                    static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
-                }
-                NNUE_STACKS.with(|stacks| {
-                    let mut stacks = stacks.borrow_mut();
-                    stacks.reset();
-                    process_record(
-                        record,
-                        &mut stacks,
-                        max_ply,
-                        false,
-                        false,
-                        score_clip,
-                        false,
-                        source_fv_scale,
-                        target_fv_scale,
-                    )
-                })
-            })
-            .collect();
+        let results: Vec<ProcessResult> = chunk.par_iter().map(eval_record).collect();
 
         let mut bytes: Vec<u8> = Vec::with_capacity(results.len() * SCORE_RECORD_SIZE as usize);
         let mut errors = 0u64;
@@ -5454,6 +5476,120 @@ mod marker_tests {
 
         // 旧世代 (格納 9 / routing 8) net は override flag で警告付きに通す。
         assert!(validate_progress_routing_buckets(Some(8), 9, true).is_ok());
+    }
+
+    /// record 番号から一意な入力 score を作る (順序検証用。線形なので重複しない)。
+    fn pipeline_input_score(i: u64) -> i16 {
+        (i as i16) * 3 - 11
+    }
+
+    /// 統合テスト用の record 評価: score を 2 倍にした PSV を返す (NNUE 非依存)。
+    fn pipeline_double_score(record: &[u8; PackedSfenValue::SIZE]) -> ProcessResult {
+        let psv = PackedSfenValue::from_bytes(record).expect("test record must parse");
+        let doubled = PackedSfenValue {
+            score: psv.score.wrapping_mul(2),
+            ..psv
+        };
+        ProcessResult::Ok(doubled.to_bytes(), false)
+    }
+
+    /// [`run_nnue_scores_pipeline`] の統合テスト: 小 chunk で順序保存・chunk 境界・
+    /// 最終端数・エラー chunk の fail-closed prefix・件数 resume を一気に固定する。
+    #[test]
+    fn nnue_scores_pipeline_preserves_order_and_resumes_after_error_chunk() {
+        let dir = tempfile::tempdir().unwrap();
+        let n: u64 = 25;
+        let input = dir.path().join("in.psv");
+        let mut input_bytes = Vec::new();
+        for i in 0..n {
+            input_bytes.extend_from_slice(&test_psv(pipeline_input_score(i)).to_bytes());
+        }
+        std::fs::write(&input, &input_bytes).unwrap();
+        // fingerprint は NNUE の path/size/mtime しか見ないため中身は任意でよい。
+        let nnue = dir.path().join("nn.bin");
+        std::fs::write(&nnue, b"not a real net").unwrap();
+        let out_dir = dir.path().join("scores");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let output = out_dir.join("in.psv.scores.i16");
+
+        let cli = Cli::try_parse_from([
+            "rescore_psv",
+            "--input",
+            input.to_str().unwrap(),
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+            "--nnue",
+            nnue.to_str().unwrap(),
+            "--out-scores",
+        ])
+        .unwrap();
+        let mut expected = Vec::new();
+        for i in 0..n {
+            expected.extend_from_slice(&pipeline_input_score(i).wrapping_mul(2).to_le_bytes());
+        }
+        let mprog = MultiFileProgress::new(3 * n, 3, "test");
+
+        // chunk_size 4 / 25 records = 満杯 6 chunk + 端数 1 record。sidecar は入力順の
+        // 期待値と bit 一致し、`.done` へ昇格して in-progress marker は消える。
+        let input_pathbuf = input.clone();
+        run_nnue_scores_pipeline(
+            &cli,
+            &input_pathbuf,
+            &output,
+            n,
+            &mprog.start_file("full", 1, n),
+            4,
+            &pipeline_double_score,
+        )
+        .unwrap();
+        assert_eq!(std::fs::read(&output).unwrap(), expected);
+        assert!(marker_path_for(&output).exists());
+        assert!(!in_progress_marker_path_for(&output).exists());
+
+        // 作り直し: record 10 (chunk 2 = record 8..12 に含まれる) がエラーになる評価で
+        // 流すと、chunk 0..=1 の 8 records だけが書かれた時点で fail-closed に停止し、
+        // 既存 prefix は行対応を保つ。in-progress marker は残り `.done` は無い。
+        std::fs::remove_file(marker_path_for(&output)).unwrap();
+        std::fs::remove_file(&output).unwrap();
+        let error_score = pipeline_input_score(10);
+        let inject_error = move |record: &[u8; PackedSfenValue::SIZE]| -> ProcessResult {
+            let psv = PackedSfenValue::from_bytes(record).expect("test record must parse");
+            if psv.score == error_score {
+                return ProcessResult::Error(anyhow::anyhow!("injected failure"));
+            }
+            pipeline_double_score(record)
+        };
+        let err = run_nnue_scores_pipeline(
+            &cli,
+            &input_pathbuf,
+            &output,
+            n,
+            &mprog.start_file("error", 2, n),
+            4,
+            &inject_error,
+        )
+        .expect_err("a chunk containing an error must abort before writing");
+        assert!(err.to_string().contains("score sidecar aborted"), "{err}");
+        let partial = std::fs::read(&output).unwrap();
+        assert_eq!(partial, expected[..8 * 2], "prefix must stay row-aligned");
+        assert!(!marker_path_for(&output).exists());
+        assert!(in_progress_marker_path_for(&output).exists());
+
+        // 件数 resume: fingerprint 一致の in-progress marker が残っているので record 8
+        // から追記され、最終 sidecar は一気通貫実行と bit 一致して `.done` へ昇格する。
+        run_nnue_scores_pipeline(
+            &cli,
+            &input_pathbuf,
+            &output,
+            n,
+            &mprog.start_file("resume", 3, n),
+            4,
+            &pipeline_double_score,
+        )
+        .unwrap();
+        assert_eq!(std::fs::read(&output).unwrap(), expected);
+        assert!(marker_path_for(&output).exists());
+        assert!(!in_progress_marker_path_for(&output).exists());
     }
 
     #[test]

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -51,14 +51,12 @@ use rayon::prelude::*;
 use std::cell::RefCell;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 // mpsc/Arc/Mutex/Instant は ONNX 直推論パイプライン専用（バッチ供給の Receiver 共有・
 // フェーズ計時）。ONNX 無効ビルドでの unused import を避けるため cfg で囲う。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 use sha2::{Digest, Sha256};
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 use std::sync::mpsc;
@@ -124,6 +122,12 @@ struct Cli {
     /// progresskpabs 用の進行度係数ファイル。
     #[arg(long)]
     ls_progress_coeff: Option<PathBuf>,
+
+    /// --ls-progress-buckets が NNUE ファイルの格納 bucket 数と異なる指定を警告付きで
+    /// 許可する。格納 9 bucket を floor(p*8) routing で学習した旧世代 net の再評価
+    /// 専用。通常の net は格納数 = routing 数なので、不一致は指定ミスとして拒否される。
+    #[arg(long)]
+    allow_routing_buckets_mismatch: bool,
 
     /// qsearch評価を使用（デフォルトは静的評価）
     #[arg(long)]
@@ -365,7 +369,6 @@ fn is_same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
 /// 既存出力パスが symlink でないこと、未作成・既存どちらでも入力パスと衝突
 /// しないことを検証する。既存ファイルが入力の hardlink である場合も検出する
 /// （Unix のみ、`MetadataExt::dev/ino` で同一 inode を判定）。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn ensure_safe_output_path(
     predicted: &std::path::Path,
     canonical_input: &std::path::Path,
@@ -673,6 +676,10 @@ fn main() -> Result<()> {
     let use_onnx = cli.onnx_model.is_some();
     let use_dlshogi_onnx = cli.dlshogi_onnx_model.is_some();
 
+    // --out-scores の NNUE 静的評価モード: NNUE を直接ロードし、qsearch も探索も
+    // 使わない構成のみ。行対応を崩す/出力内容を混ぜる他モードとの併用は下で reject。
+    let nnue_static_scores =
+        cli.out_scores && !use_engine && !use_onnx && !use_dlshogi_onnx && cli.nnue.is_some();
     if cli.out_scores {
         if cli.limit > 0 {
             anyhow::bail!(
@@ -684,21 +691,23 @@ fn main() -> Result<()> {
                 "--out-scores cannot be combined with --delete-input because the base PSV is required to interpret the score sidecar"
             );
         }
-        if !use_dlshogi_onnx {
-            anyhow::bail!("--out-scores requires --dlshogi-onnx-model");
+        if !use_dlshogi_onnx && !nnue_static_scores {
+            anyhow::bail!(
+                "--out-scores requires --dlshogi-onnx-model or --nnue (static evaluation)"
+            );
         }
         if use_onnx
             || use_engine
-            || cli.nnue.is_some()
             || cli.use_qsearch
             || cli.search_depth.is_some()
             || cli.qsearch_leaf_label
             || cli.apply_qsearch_leaf
             || cli.expand_output_dir.is_some()
             || cli.qsearch_leaf_replacement_output.is_some()
+            || (use_dlshogi_onnx && cli.nnue.is_some())
         {
             anyhow::bail!(
-                "--out-scores supports only direct --dlshogi-onnx-model inference and cannot be combined with other evaluation, qsearch, search, expand, or replacement modes"
+                "--out-scores supports only direct --dlshogi-onnx-model inference or NNUE static evaluation and cannot be combined with other evaluation, qsearch, search, expand, or replacement modes"
             );
         }
         if cli.skip_in_check {
@@ -911,6 +920,13 @@ fn main() -> Result<()> {
                     (LayerStackBucketMode::KingRank9, None) => {}
                     _ => unreachable!(),
                 }
+                if matches!(mode, LayerStackBucketMode::ProgressKPAbs) {
+                    validate_progress_routing_buckets(
+                        cli.ls_progress_buckets,
+                        stored,
+                        cli.allow_routing_buckets_mismatch,
+                    )?;
+                }
                 configure_layer_stack_routing(mode, stored, cli.ls_progress_buckets)
                     .map_err(anyhow::Error::msg)?;
             }
@@ -1086,9 +1102,9 @@ fn main() -> Result<()> {
 
         // ONNX モードでは marker ベースで skip / truncate 判定
         #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
-        let mut use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx);
+        let mut use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx || nnue_static_scores);
         #[cfg(not(any(feature = "aobazero-onnx", feature = "dlshogi-onnx")))]
-        let use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx);
+        let use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx || nnue_static_scores);
         #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
         if use_onnx || use_dlshogi_onnx {
             let (model_kind, onnx_path): (&str, &std::path::Path) = if use_onnx {
@@ -1137,6 +1153,21 @@ fn main() -> Result<()> {
                     use_legacy_resume_check = true;
                 }
             }
+        }
+
+        // NNUE 静的評価 sidecar は完了 marker で skip / 作り直しを判定する
+        // (途中再開の判定は process_file_nnue_scores 内の in-progress marker が担う)。
+        if nnue_static_scores
+            && nnue_scores_marker_decide(&cli, input_path, &output_path, process_count)?
+        {
+            eprintln!(
+                "=== [{}/{}] Skipping (marker matches): {} ===",
+                file_idx + 1,
+                total_files,
+                output_path.display()
+            );
+            rprog.skip_file(process_count);
+            continue;
         }
 
         // legacy resume / skip 判定（NNUE/USI 全モード、または ONNX 無 marker + expand 無効）
@@ -1237,6 +1268,8 @@ fn main() -> Result<()> {
                 )?;
             } else if cli.search_depth.is_some() {
                 process_file_with_search(&cli, input_path, &output_path, process_count, &fprog)?;
+            } else if nnue_static_scores {
+                process_file_nnue_scores(&cli, input_path, &output_path, process_count, &fprog)?;
             } else {
                 process_file(&cli, input_path, &output_path, process_count, &fprog)?;
             }
@@ -1284,6 +1317,320 @@ fn main() -> Result<()> {
 }
 
 /// ファイルを処理
+/// progresskpabs の routing bucket 数指定と NNUE 格納 bucket 数の整合を検証する。
+///
+/// 現行世代の net は格納数 = 学習時 routing 数なので、不一致は bucket 数の指定ミス
+/// (誤った routing は全行を無警告で誤評価にする) として拒否する。格納 bucket 数より
+/// 少ない routing で学習した旧世代 net だけが正当な不一致で、
+/// `--allow-routing-buckets-mismatch` で明示的に通す。未指定 (None) の explicit 必須
+/// 検査は `configure_layer_stack_routing` 側が担う。
+fn validate_progress_routing_buckets(
+    requested: Option<usize>,
+    stored: usize,
+    allow_mismatch: bool,
+) -> Result<()> {
+    let Some(requested) = requested else {
+        return Ok(());
+    };
+    if requested == stored {
+        return Ok(());
+    }
+    if allow_mismatch {
+        eprintln!(
+            "Warning: --ls-progress-buckets {requested} != stored bucket count {stored}; \
+             proceeding because --allow-routing-buckets-mismatch is set"
+        );
+        return Ok(());
+    }
+    anyhow::bail!(
+        "--ls-progress-buckets {requested} does not match the stored bucket count {stored} of \
+         the NNUE file. A mismatched routing count silently mis-routes every position. Pass \
+         the stored count, or pass --allow-routing-buckets-mismatch if this net was really \
+         trained with {requested}-bucket routing on a {stored}-bucket layout."
+    );
+}
+
+/// NNUE 静的評価 score sidecar の同一性 fingerprint を構築する。
+///
+/// model_* は NNUE ファイル (path / size / mtime)、nnue_* は出力スコアを変える
+/// routing (`--ls-bucket-mode` / `--ls-progress-buckets` / `--ls-progress-coeff`
+/// の path + sha256) とスケール変換 (`--source-fv-scale` / `--target-fv-scale`)。
+/// `eval_scale_bits` / `onnx_draw_ply` は ONNX 専用キーだが marker format 上
+/// 必須のため固定値 (0) を書く。
+fn build_nnue_scores_fingerprint(
+    cli: &Cli,
+    input_path: &std::path::Path,
+    process_count: u64,
+) -> Result<RunFingerprint> {
+    let nnue = cli
+        .nnue
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("NNUE score sidecar mode requires --nnue"))?;
+    let model_path = nnue
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize --nnue {}", nnue.display()))?;
+    ensure_marker_safe_path("--nnue", &model_path)?;
+    let (model_size, model_mtime_ns) = file_size_mtime_ns(&model_path)?;
+    let input_path = input_path
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", input_path.display()))?;
+    ensure_marker_safe_path("input", &input_path)?;
+    let (input_size, input_mtime_ns) = file_size_mtime_ns(&input_path)?;
+    let (nnue_ls_progress_coeff_path, nnue_ls_progress_coeff_sha256) =
+        match cli.ls_progress_coeff.as_deref() {
+            Some(path) => {
+                let canonical = path.canonicalize().with_context(|| {
+                    format!("Failed to canonicalize --ls-progress-coeff {}", path.display())
+                })?;
+                ensure_marker_safe_path("--ls-progress-coeff", &canonical)?;
+                let bytes = fs::read(&canonical).with_context(|| {
+                    format!("Failed to read --ls-progress-coeff {}", canonical.display())
+                })?;
+                let sha256 = format!("{:x}", Sha256::digest(bytes));
+                (Some(canonical), Some(sha256))
+            }
+            None => (None, None),
+        };
+    Ok(RunFingerprint {
+        version: MARKER_VERSION,
+        mode: "nnue-static".to_string(),
+        model_kind: "nnue".to_string(),
+        model_path,
+        model_size,
+        model_mtime_ns,
+        input_path,
+        input_size,
+        input_mtime_ns,
+        process_count,
+        out_scores: true,
+        skip_in_check: false,
+        score_clip: cli.score_clip,
+        eval_scale_bits: 0,
+        use_tensorrt: None,
+        onnx_draw_ply: 0,
+        qsearch_leaf_label: false,
+        qsearch_max_ply: None,
+        qsearch_nnue_path: None,
+        qsearch_nnue_size: None,
+        qsearch_nnue_mtime_ns: None,
+        qsearch_ls_bucket_mode: None,
+        qsearch_ls_progress_buckets: None,
+        qsearch_ls_progress_coeff_path: None,
+        qsearch_ls_progress_coeff_sha256: None,
+        nnue_ls_bucket_mode: cli.ls_bucket_mode.clone(),
+        nnue_ls_progress_buckets: cli.ls_progress_buckets,
+        nnue_ls_progress_coeff_path,
+        nnue_ls_progress_coeff_sha256,
+        nnue_source_fv_scale: Some(cli.source_fv_scale),
+        nnue_target_fv_scale: Some(cli.target_fv_scale),
+        expand: false,
+        expand_threshold_bits: None,
+        expand_skip_parent_in_check: None,
+        expand_skip_child_in_check: None,
+        expand_output_path: None,
+        replacement: false,
+        replacement_output_path: None,
+    })
+}
+
+/// NNUE 静的評価 sidecar の完了 marker を判定する。`true` = 完了済み (skip)。
+///
+/// marker 不一致 (net / 入力 / routing / スケールの差し替え) は sidecar を空にして
+/// から `.done` を削除する。逆順だと truncate 失敗時に「古い marker + 別設定の
+/// sidecar」が残って誤 skip し得る。途中再開の判定は
+/// [`process_file_nnue_scores`] 内の in-progress marker が担う。
+fn nnue_scores_marker_decide(
+    cli: &Cli,
+    input_path: &std::path::Path,
+    output_path: &std::path::Path,
+    process_count: u64,
+) -> Result<bool> {
+    let current = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    ensure_safe_output_path(output_path, &current.input_path)?;
+    let marker_path = marker_path_for(output_path);
+    if marker_path.exists() {
+        let marker = parse_marker(&marker_path)?;
+        let body_matches = output_path.exists()
+            && fs::metadata(output_path)?.len() == marker.output_sizes.rescore_output_size;
+        if marker.fingerprint == current && body_matches {
+            remove_in_progress_marker(output_path)?;
+            return Ok(true);
+        }
+        if output_path.exists() {
+            File::options().write(true).open(output_path)?.set_len(0)?;
+        }
+        fs::remove_file(&marker_path)
+            .with_context(|| format!("Failed to remove stale marker {}", marker_path.display()))?;
+    }
+    Ok(false)
+}
+
+/// NNUE 静的評価で little-endian i16 score sidecar を出力する。
+///
+/// 不変条件は「sidecar 行 i = 入力 record i」の行対応で、エラーを含むチャンクは
+/// 1 byte も書かない ([`write_rescore_batch`])。in-progress marker の fingerprint が
+/// 一致すれば件数ベースで追記再開し、完了時に行数 == 入力 record 数を検証して
+/// `.done` へ昇格する。Ctrl-C はチャンク境界で停止し、marker を残して次回の
+/// 再開に備える。
+fn process_file_nnue_scores(
+    cli: &Cli,
+    input_path: &PathBuf,
+    output_path: &PathBuf,
+    process_count: u64,
+    progress: &FileProgress,
+) -> Result<()> {
+    const CHUNK_SIZE: usize = 1_000_000;
+    const SCORE_RECORD_SIZE: u64 = 2;
+
+    let start_fingerprint = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    prepare_in_progress_marker(output_path, &start_fingerprint, false)?
+        .context("out_scores=true did not create an in-progress marker")?;
+    let resume_count = prepare_resume_count(output_path, SCORE_RECORD_SIZE, true)?;
+    if resume_count > process_count {
+        anyhow::bail!(
+            "Existing sidecar has {resume_count} records but the input has only {process_count}. \
+             Delete the sidecar {} and its .in-progress marker to regenerate.",
+            output_path.display()
+        );
+    }
+
+    let in_file = File::open(input_path)
+        .with_context(|| format!("Failed to open {}", input_path.display()))?;
+    let mut reader = BufReader::with_capacity(8 * 1024 * 1024, in_file);
+    seek_to_record(&mut reader, resume_count)?;
+    let out_file = File::options()
+        .create(true)
+        .append(true)
+        .open(output_path)
+        .with_context(|| format!("Failed to open {}", output_path.display()))?;
+    let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
+
+    let max_ply = cli.max_ply;
+    let score_clip = cli.score_clip;
+    let source_fv_scale = cli.source_fv_scale;
+    let target_fv_scale = cli.target_fv_scale;
+    let verbose = cli.verbose;
+
+    progress.set_message("Processing...");
+    if resume_count > 0 {
+        eprintln!("Resuming sidecar at record {resume_count}/{process_count}");
+        progress.inc(resume_count);
+    }
+    let mut total_written = resume_count;
+    let mut interrupted = false;
+
+    while total_written < process_count {
+        if INTERRUPTED.load(Ordering::SeqCst) {
+            interrupted = true;
+            break;
+        }
+
+        let want = (CHUNK_SIZE as u64).min(process_count - total_written) as usize;
+        let mut chunk: Vec<[u8; PackedSfenValue::SIZE]> = Vec::with_capacity(want);
+        let mut buffer = [0u8; PackedSfenValue::SIZE];
+        for _ in 0..want {
+            match reader.read_exact(&mut buffer) {
+                Ok(()) => chunk.push(buffer),
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        if chunk.is_empty() {
+            break;
+        }
+
+        // 行対応維持のためチャンク全件を評価してから一括書き出しする。process_file と
+        // 違い INTERRUPTED での record 単位 early-out はしない (None 化した行が
+        // fail-closed でエラー扱いになり、正常な中断がエラー終了に化けるため)。
+        let results: Vec<ProcessResult> = chunk
+            .par_iter()
+            .map(|record| {
+                thread_local! {
+                    static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
+                }
+                NNUE_STACKS.with(|stacks| {
+                    let mut stacks = stacks.borrow_mut();
+                    stacks.reset();
+                    process_record(
+                        record,
+                        &mut stacks,
+                        max_ply,
+                        false,
+                        false,
+                        score_clip,
+                        false,
+                        source_fv_scale,
+                        target_fv_scale,
+                    )
+                })
+            })
+            .collect();
+
+        let mut bytes: Vec<u8> = Vec::with_capacity(results.len() * SCORE_RECORD_SIZE as usize);
+        let mut errors = 0u64;
+        for result in &results {
+            match result {
+                ProcessResult::Ok(record, _clipped) => match PackedSfenValue::from_bytes(record) {
+                    Some(psv) => append_rescore_bytes(&mut bytes, &psv, true),
+                    None => errors += 1,
+                },
+                // skip_in_check=false 固定なので Skip は返らない想定。防御として
+                // 行落ちさせず fail-closed のエラー扱いにする。
+                ProcessResult::Skip => errors += 1,
+                ProcessResult::Error(e) => {
+                    errors += 1;
+                    if verbose {
+                        eprintln!("Error processing record: {e}");
+                    }
+                }
+            }
+        }
+        write_rescore_batch(&mut writer, &bytes, true, errors)?;
+        total_written += chunk.len() as u64;
+        progress.inc(chunk.len() as u64);
+    }
+
+    writer.flush()?;
+
+    if interrupted {
+        progress.abandon_with_message("Interrupted");
+        eprintln!(
+            "Interrupted at {total_written}/{process_count} records; the in-progress marker is \
+             kept so the next run resumes by record count"
+        );
+        return Ok(());
+    }
+    if total_written != process_count {
+        anyhow::bail!(
+            "Input ended early: wrote {total_written} of {process_count} score records for {}",
+            input_path.display()
+        );
+    }
+
+    let final_fingerprint = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    reject_changed_sidecar_fingerprint(
+        output_path,
+        &start_fingerprint,
+        &final_fingerprint,
+        "during the run",
+    )?;
+    let rescore_output_size = fs::metadata(output_path)?.len();
+    promote_score_sidecar_marker(
+        output_path,
+        &DoneMarker {
+            fingerprint: final_fingerprint,
+            output_sizes: OutputSizes {
+                rescore_output_size,
+                expand_output_size: None,
+                replacement_output_size: None,
+            },
+        },
+    )?;
+    progress.finish_with_message("Done");
+    eprintln!("Wrote {total_written} score records");
+    Ok(())
+}
+
 fn process_file(
     cli: &Cli,
     input_path: &PathBuf,
@@ -2236,7 +2583,6 @@ fn onnx_ort_err(e: ort::Error) -> anyhow::Error {
 }
 
 /// score 決定後のレコードを通常 PSV または score sidecar として直列化する。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn append_rescore_bytes(output: &mut Vec<u8>, psv: &PackedSfenValue, out_scores: bool) {
     if out_scores {
         output.extend_from_slice(&psv.score.to_le_bytes());
@@ -2249,7 +2595,6 @@ fn append_rescore_bytes(output: &mut Vec<u8>, psv: &PackedSfenValue, out_scores:
 ///
 /// reader の decode 失敗と producer の局面構築失敗を同じ errors に集約し、
 /// seq 順 writer が書き出し直前に拒否することで、既存 prefix の行対応を保つ。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_rescore_batch<W: Write>(
     writer: &mut W,
     bytes: &[u8],
@@ -2267,7 +2612,6 @@ fn write_rescore_batch<W: Write>(
 
 /// 既存出力のレコード数を返す。通常 PSV の末尾 partial record は従来どおり
 /// 切り捨てて自己修復するが、事後検出不能な score sidecar は fail-closed にする。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn prepare_resume_count(
     output_path: &std::path::Path,
     output_record_size: u64,
@@ -2301,7 +2645,6 @@ fn prepare_resume_count(
 
 /// 入力を既処理レコードの直後へ移動する。巨大 sidecar の resume で入力 prefix を
 /// 空読みせず、checked offset に直接 seek する。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn seek_to_record<R: Seek>(reader: &mut R, record_count: u64) -> Result<u64> {
     let offset = record_count
         .checked_mul(PackedSfenValue::SIZE as u64)
@@ -2378,11 +2721,9 @@ struct ExpandConfig<'a> {
 }
 
 /// 完了マーカーのフォーマットバージョン
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 const MARKER_VERSION: u32 = 1;
 
 /// 完了マーカーの fingerprint 部（出力内容を一意に決める実行設定）
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RunFingerprint {
     version: u32,
@@ -2417,6 +2758,15 @@ struct RunFingerprint {
     qsearch_ls_progress_buckets: Option<usize>,
     qsearch_ls_progress_coeff_path: Option<PathBuf>,
     qsearch_ls_progress_coeff_sha256: Option<String>,
+    // NNUE 静的評価 sidecar (mode="nnue-static") のみ Some。model_* が NNUE 本体を
+    // 指すのに対し、こちらは出力スコアを変える routing / スケール設定を固定する。
+    // LayerStacks でない NNUE では routing 3 兄弟は None のまま。
+    nnue_ls_bucket_mode: Option<String>,
+    nnue_ls_progress_buckets: Option<usize>,
+    nnue_ls_progress_coeff_path: Option<PathBuf>,
+    nnue_ls_progress_coeff_sha256: Option<String>,
+    nnue_source_fv_scale: Option<i32>,
+    nnue_target_fv_scale: Option<i32>,
     expand: bool,
     expand_threshold_bits: Option<u32>,
     expand_skip_parent_in_check: Option<bool>,
@@ -2429,7 +2779,6 @@ struct RunFingerprint {
 }
 
 /// 完了マーカーの出力サイズ情報（fingerprint とは分離）
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OutputSizes {
     rescore_output_size: u64,
@@ -2438,7 +2787,6 @@ struct OutputSizes {
 }
 
 /// 完了マーカー全体（fingerprint + output sizes）
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DoneMarker {
     fingerprint: RunFingerprint,
@@ -2446,7 +2794,6 @@ struct DoneMarker {
 }
 
 /// `<rescore_output>.done` を返す
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
     let mut s = rescore_output.as_os_str().to_owned();
     s.push(".done");
@@ -2454,7 +2801,6 @@ fn marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
 }
 
 /// `<rescore_output>.in-progress` を返す
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn in_progress_marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
     let mut s = rescore_output.as_os_str().to_owned();
     s.push(".in-progress");
@@ -2462,7 +2808,6 @@ fn in_progress_marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
 }
 
 /// ファイルの `(len, modified_unix_ns)` を取得
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn file_size_mtime_ns(path: &std::path::Path) -> Result<(u64, u128)> {
     let m = fs::metadata(path).with_context(|| format!("Failed to stat {}", path.display()))?;
     let mtime = m
@@ -2475,7 +2820,6 @@ fn file_size_mtime_ns(path: &std::path::Path) -> Result<(u64, u128)> {
 }
 
 /// `DoneMarker` をテキスト key=value 形式にシリアライズ
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn serialize_marker(marker: &DoneMarker) -> String {
     let f = &marker.fingerprint;
     let mut out = String::new();
@@ -2536,6 +2880,24 @@ fn serialize_marker(marker: &DoneMarker) -> String {
             let _ = writeln!(out, "qsearch_ls_progress_coeff_sha256={sha256}");
         }
     }
+    if let Some(mode) = &f.nnue_ls_bucket_mode {
+        let _ = writeln!(out, "nnue_ls_bucket_mode={mode}");
+    }
+    if let Some(buckets) = f.nnue_ls_progress_buckets {
+        let _ = writeln!(out, "nnue_ls_progress_buckets={buckets}");
+    }
+    if let Some(path) = &f.nnue_ls_progress_coeff_path {
+        let _ = writeln!(out, "nnue_ls_progress_coeff_path={}", path.display());
+    }
+    if let Some(sha256) = &f.nnue_ls_progress_coeff_sha256 {
+        let _ = writeln!(out, "nnue_ls_progress_coeff_sha256={sha256}");
+    }
+    if let Some(v) = f.nnue_source_fv_scale {
+        let _ = writeln!(out, "nnue_source_fv_scale={v}");
+    }
+    if let Some(v) = f.nnue_target_fv_scale {
+        let _ = writeln!(out, "nnue_target_fv_scale={v}");
+    }
     let _ = writeln!(out, "expand={}", f.expand);
     if f.expand {
         let _ = writeln!(
@@ -2595,7 +2957,6 @@ fn serialize_marker(marker: &DoneMarker) -> String {
 }
 
 /// マーカーファイルをパース（key=value テキスト形式、行頭空白・コメントは未対応）
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
     let text = fs::read_to_string(path)
         .with_context(|| format!("Failed to read marker {}", path.display()))?;
@@ -2692,6 +3053,21 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
             .get("qsearch_ls_progress_coeff_path")
             .map(PathBuf::from),
         qsearch_ls_progress_coeff_sha256: map.get("qsearch_ls_progress_coeff_sha256").cloned(),
+        nnue_ls_bucket_mode: map.get("nnue_ls_bucket_mode").cloned(),
+        nnue_ls_progress_buckets: map
+            .get("nnue_ls_progress_buckets")
+            .map(|value| value.parse().context("invalid nnue_ls_progress_buckets"))
+            .transpose()?,
+        nnue_ls_progress_coeff_path: map.get("nnue_ls_progress_coeff_path").map(PathBuf::from),
+        nnue_ls_progress_coeff_sha256: map.get("nnue_ls_progress_coeff_sha256").cloned(),
+        nnue_source_fv_scale: map
+            .get("nnue_source_fv_scale")
+            .map(|value| value.parse().context("invalid nnue_source_fv_scale"))
+            .transpose()?,
+        nnue_target_fv_scale: map
+            .get("nnue_target_fv_scale")
+            .map(|value| value.parse().context("invalid nnue_target_fv_scale"))
+            .transpose()?,
         expand,
         expand_threshold_bits: if expand {
             Some(parse_hex_u32(get("expand_threshold_bits")?)?)
@@ -2748,14 +3124,12 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
 /// マーカーを atomic に書き出す（tmp に書く → sync_all → rename）。
 /// 他の出力パスと同様、tmp / final が symlink の場合は拒否する
 /// （symlink を follow して任意ファイルを上書きするのを防ぐ）。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) -> Result<()> {
     let final_path = marker_path_for(rescore_output);
     write_marker_atomic_at(&final_path, marker)
 }
 
 /// 指定したパスへマーカーを atomic に書き出す。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_marker_atomic_at(final_path: &std::path::Path, marker: &DoneMarker) -> Result<()> {
     let mut tmp_os = final_path.as_os_str().to_owned();
     tmp_os.push(".tmp");
@@ -2798,7 +3172,6 @@ fn write_marker_atomic_at(final_path: &std::path::Path, marker: &DoneMarker) -> 
 }
 
 /// score sidecar の run 開始時に選ぶ処理方法。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SidecarStartDecision {
     Resume,
@@ -2806,7 +3179,6 @@ enum SidecarStartDecision {
 }
 
 /// in-progress marker が通常ファイルなら削除する。symlink は追跡せず拒否する。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn remove_in_progress_marker(rescore_output: &std::path::Path) -> Result<()> {
     let path = in_progress_marker_path_for(rescore_output);
     let metadata = match fs::symlink_metadata(&path) {
@@ -2831,7 +3203,6 @@ fn remove_in_progress_marker(rescore_output: &std::path::Path) -> Result<()> {
 ///
 /// 完了 marker と同じ key=value 形式を再利用し、output size は未完了を表す 0 とする。
 /// fingerprint だけを resume の根拠にし、変化する sidecar 自身の mtime は記録しない。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_in_progress_marker(
     rescore_output: &std::path::Path,
     fingerprint: &RunFingerprint,
@@ -2852,7 +3223,6 @@ fn write_in_progress_marker(
 /// full PSV では何もせず、従来の marker / record-count 判定へ委ねる。sidecar では
 /// 出力と in-progress marker の両方が存在し fingerprint が一致するときだけ追記を許可する。
 /// それ以外は出力を truncate して現在 fingerprint の marker を書き直す。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn prepare_in_progress_marker(
     rescore_output: &std::path::Path,
     current: &RunFingerprint,
@@ -2906,7 +3276,6 @@ fn prepare_in_progress_marker(
 
 /// sidecar の正常完了を `.done` へ昇格し、その後 in-progress marker を削除する。
 /// この順序なら両操作の間で停止しても、次回は `.done` を正として回収できる。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn promote_score_sidecar_marker(
     rescore_output: &std::path::Path,
     marker: &DoneMarker,
@@ -2916,7 +3285,6 @@ fn promote_score_sidecar_marker(
 }
 
 /// sidecar run の開始時 fingerprint が現在も有効か確認する。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn ensure_sidecar_fingerprint_unchanged(
     start: &RunFingerprint,
     current: &RunFingerprint,
@@ -2931,7 +3299,6 @@ fn ensure_sidecar_fingerprint_unchanged(
 }
 
 /// run 中の fingerprint 変更を検出した sidecar を、次回 resume 不能な状態へ戻す。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn reject_changed_sidecar_fingerprint(
     rescore_output: &std::path::Path,
     start: &RunFingerprint,
@@ -2962,7 +3329,6 @@ fn reject_changed_sidecar_fingerprint(
 /// 現実的には `=` を含むパスだけが稀に発生する（例:
 /// `v1.0=alpha/model.onnx`）。非 UTF-8 と改行はほぼ起こらないが、同じ
 /// 検証枠で拾っておく。遭遇時はパスをリネームすることで回避可能。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn ensure_marker_safe_path(kind: &str, path: &std::path::Path) -> Result<()> {
     let s = path.to_str().ok_or_else(|| {
         anyhow::anyhow!(
@@ -3087,6 +3453,12 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
             .flatten(),
         qsearch_ls_progress_coeff_path,
         qsearch_ls_progress_coeff_sha256,
+        nnue_ls_bucket_mode: None,
+        nnue_ls_progress_buckets: None,
+        nnue_ls_progress_coeff_path: None,
+        nnue_ls_progress_coeff_sha256: None,
+        nnue_source_fv_scale: None,
+        nnue_target_fv_scale: None,
         expand: config.expand.is_some(),
         expand_threshold_bits: config.expand.map(|e| e.threshold.to_bits()),
         expand_skip_parent_in_check: config.expand.map(|e| e.skip_parent_in_check),
@@ -3099,7 +3471,6 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
 
 /// 未作成出力ファイルの予定 canonical パスを構築する。
 /// parent dir を canonicalize して file_name と join する。
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn canonicalize_predicted_path(path: &std::path::Path) -> Result<PathBuf> {
     let parent = path
         .parent()
@@ -4637,7 +5008,7 @@ fn process_file_with_dlshogi_onnx(
     )
 }
 
-#[cfg(all(test, any(feature = "aobazero-onnx", feature = "dlshogi-onnx")))]
+#[cfg(test)]
 mod marker_tests {
     use super::*;
     use std::io::{Read, Write};
@@ -5030,6 +5401,59 @@ mod marker_tests {
         let error = prepare_resume_count(&sidecar, 2, true).unwrap_err();
         assert!(error.to_string().contains("Delete the .in-progress marker"));
         assert_eq!(std::fs::metadata(sidecar).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn nnue_static_marker_keys_roundtrip() {
+        const NNUE_KEYS: &str = concat!(
+            "nnue_ls_bucket_mode=progresskpabs\n",
+            "nnue_ls_progress_buckets=9\n",
+            "nnue_ls_progress_coeff_path=/tmp/progress.bin\n",
+            "nnue_ls_progress_coeff_sha256=deadbeef\n",
+            "nnue_source_fv_scale=14\n",
+            "nnue_target_fv_scale=14\n",
+        );
+        let m = parse_text(&base_marker(NNUE_KEYS));
+        assert_eq!(m.fingerprint.nnue_ls_bucket_mode.as_deref(), Some("progresskpabs"));
+        assert_eq!(m.fingerprint.nnue_ls_progress_buckets, Some(9));
+        assert_eq!(
+            m.fingerprint.nnue_ls_progress_coeff_path,
+            Some(PathBuf::from("/tmp/progress.bin"))
+        );
+        assert_eq!(m.fingerprint.nnue_ls_progress_coeff_sha256.as_deref(), Some("deadbeef"));
+        assert_eq!(m.fingerprint.nnue_source_fv_scale, Some(14));
+        assert_eq!(m.fingerprint.nnue_target_fv_scale, Some(14));
+        assert_eq!(m, parse_text(&serialize_marker(&m)));
+    }
+
+    #[test]
+    fn old_marker_without_nnue_keys_defaults_to_none_and_mismatches_new_marker() {
+        let old = parse_text(&base_marker(""));
+        assert_eq!(old.fingerprint.nnue_ls_bucket_mode, None);
+        assert_eq!(old.fingerprint.nnue_ls_progress_buckets, None);
+        assert_eq!(old.fingerprint.nnue_ls_progress_coeff_path, None);
+        assert_eq!(old.fingerprint.nnue_ls_progress_coeff_sha256, None);
+        assert_eq!(old.fingerprint.nnue_source_fv_scale, None);
+        assert_eq!(old.fingerprint.nnue_target_fv_scale, None);
+
+        // routing 設定の差は fingerprint 不一致 → 再生成側に倒れる。
+        let with_keys = parse_text(&base_marker("nnue_ls_progress_buckets=8\n"));
+        assert_ne!(old.fingerprint, with_keys.fingerprint);
+    }
+
+    #[test]
+    fn progress_routing_bucket_mismatch_is_rejected_without_override() {
+        // 未指定は configure_layer_stack_routing 側の explicit 必須検査に委ねる。
+        assert!(validate_progress_routing_buckets(None, 9, false).is_ok());
+        assert!(validate_progress_routing_buckets(Some(9), 9, false).is_ok());
+
+        // 9-bucket net への 8 指定 (無警告の誤 routing を生んでいた組合せ) は拒否。
+        let err = validate_progress_routing_buckets(Some(8), 9, false).unwrap_err().to_string();
+        assert!(err.contains("stored bucket count 9"), "{err}");
+        assert!(err.contains("--allow-routing-buckets-mismatch"), "{err}");
+
+        // 旧世代 (格納 9 / routing 8) net は override flag で警告付きに通す。
+        assert!(validate_progress_routing_buckets(Some(8), 9, true).is_ok());
     }
 
     #[test]

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -68,8 +68,8 @@ use std::time::Instant;
 
 use rshogi_core::nnue::{
     LayerStackBucketMode, configure_layer_stack_routing, get_network, init_nnue,
-    layer_stack_progress_coeff_required, load_progress_coeff_kpabs, parse_layer_stack_bucket_mode,
-    set_layer_stack_progress_kpabs_weights,
+    layer_stack_progress_coeff_required, load_progress_coeff_kpabs_from_bytes,
+    parse_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
 };
 use rshogi_core::position::Position;
 use rshogi_core::search::{LimitsType, Search};
@@ -886,6 +886,7 @@ fn main() -> Result<()> {
 
     // NNUEモデルのロード（NNUE内部評価モード、または ONNX ラベラー併用の
     // --qsearch-leaf-label で葉探索に NNUE を使う場合）
+    let mut nnue_scores_identity: Option<NnueScoresIdentity> = None;
     if (!use_engine && !use_onnx && !use_dlshogi_onnx) || cli.qsearch_leaf_label {
         let nnue = cli.nnue.as_ref().unwrap();
         if !nnue.exists() {
@@ -894,6 +895,7 @@ fn main() -> Result<()> {
         init_nnue(nnue).context("Failed to load NNUE model")?;
         eprintln!("NNUE model loaded: {}", nnue.display());
         let network = get_network().context("NNUE was not initialized")?;
+        let mut loaded_coeff_sha: Option<String> = None;
         match network.layer_stack_num_buckets() {
             Some(stored) => {
                 let mode_str = cli
@@ -904,8 +906,17 @@ fn main() -> Result<()> {
                     .context("--ls-bucket-mode must be progresskpabs or kingrank9")?;
                 match (mode, cli.ls_progress_coeff.as_deref()) {
                     (LayerStackBucketMode::ProgressKPAbs, Some(path)) => {
-                        let weights =
-                            load_progress_coeff_kpabs(path).map_err(anyhow::Error::msg)?;
+                        // fingerprint に書く sha256 を実際にロードした byte 列そのもの
+                        // から計算するため、ファイルは 1 回だけ読む (読み直すと
+                        // 差し替え時にロード内容と sha が乖離する)。
+                        let bytes = fs::read(path).with_context(|| {
+                            format!("Failed to read --ls-progress-coeff {}", path.display())
+                        })?;
+                        if nnue_static_scores {
+                            loaded_coeff_sha = Some(format!("{:x}", Sha256::digest(&bytes)));
+                        }
+                        let weights = load_progress_coeff_kpabs_from_bytes(&bytes)
+                            .map_err(anyhow::Error::msg)?;
                         set_layer_stack_progress_kpabs_weights(weights)
                             .map_err(anyhow::Error::msg)?;
                     }
@@ -937,6 +948,13 @@ fn main() -> Result<()> {
                 anyhow::bail!("LayerStacks routing options require a LayerStacks NNUE")
             }
             None => {}
+        }
+        // sidecar fingerprint の識別情報はロード直後のこの時点で固定する。
+        if nnue_static_scores {
+            nnue_scores_identity = Some(NnueScoresIdentity::capture(
+                nnue,
+                cli.ls_progress_coeff.as_deref().zip(loaded_coeff_sha),
+            )?);
         }
     }
 
@@ -1157,17 +1175,20 @@ fn main() -> Result<()> {
 
         // NNUE 静的評価 sidecar は完了 marker で skip / 作り直しを判定する
         // (途中再開の判定は process_file_nnue_scores 内の in-progress marker が担う)。
-        if nnue_static_scores
-            && nnue_scores_marker_decide(&cli, input_path, &output_path, process_count)?
-        {
-            eprintln!(
-                "=== [{}/{}] Skipping (marker matches): {} ===",
-                file_idx + 1,
-                total_files,
-                output_path.display()
-            );
-            rprog.skip_file(process_count);
-            continue;
+        if nnue_static_scores {
+            let identity = nnue_scores_identity
+                .as_ref()
+                .context("NNUE score sidecar identity must be captured at model load time")?;
+            if nnue_scores_marker_decide(&cli, identity, input_path, &output_path, process_count)? {
+                eprintln!(
+                    "=== [{}/{}] Skipping (marker matches): {} ===",
+                    file_idx + 1,
+                    total_files,
+                    output_path.display()
+                );
+                rprog.skip_file(process_count);
+                continue;
+            }
         }
 
         // legacy resume / skip 判定（NNUE/USI 全モード、または ONNX 無 marker + expand 無効）
@@ -1269,7 +1290,17 @@ fn main() -> Result<()> {
             } else if cli.search_depth.is_some() {
                 process_file_with_search(&cli, input_path, &output_path, process_count, &fprog)?;
             } else if nnue_static_scores {
-                process_file_nnue_scores(&cli, input_path, &output_path, process_count, &fprog)?;
+                let identity = nnue_scores_identity
+                    .as_ref()
+                    .context("NNUE score sidecar identity must be captured at model load time")?;
+                process_file_nnue_scores(
+                    &cli,
+                    identity,
+                    input_path,
+                    &output_path,
+                    process_count,
+                    &fprog,
+                )?;
             } else {
                 process_file(&cli, input_path, &output_path, process_count, &fprog)?;
             }
@@ -1350,54 +1381,111 @@ fn validate_progress_routing_buckets(
     );
 }
 
+/// NNUE score sidecar 用のモデル識別情報。
+///
+/// プロセスは NNUE と progress 係数を起動時に 1 回だけロードする。fingerprint に
+/// 書く識別情報 (path / size / mtime、係数はロードした byte 列の sha256) も
+/// ロード直後に 1 回だけ取得して固定し、以後の全 fingerprint はこの値を使う。
+/// 入力ファイルごとに stat し直すと、複数入力の長時間実行中にファイルが
+/// 差し替わった場合に「旧モデルで生成した sidecar へ新モデルの識別情報で
+/// `.done` が付き、次回誤って skip される」取り違えが起きる。
+struct NnueScoresIdentity {
+    model_path: PathBuf,
+    model_size: u64,
+    model_mtime_ns: u128,
+    coeff_path: Option<PathBuf>,
+    coeff_size: Option<u64>,
+    coeff_mtime_ns: Option<u128>,
+    coeff_sha256: Option<String>,
+}
+
+impl NnueScoresIdentity {
+    /// NNUE ロード直後に識別情報を取得する。`coeff` の sha256 はロードに使った
+    /// byte 列から計算済みの値を受け取る (ここでファイルを読み直すと、差し替え時
+    /// にロード内容と sha が乖離するため)。
+    fn capture(nnue: &std::path::Path, coeff: Option<(&std::path::Path, String)>) -> Result<Self> {
+        let model_path = nnue
+            .canonicalize()
+            .with_context(|| format!("Failed to canonicalize --nnue {}", nnue.display()))?;
+        ensure_marker_safe_path("--nnue", &model_path)?;
+        let (model_size, model_mtime_ns) = file_size_mtime_ns(&model_path)?;
+        let (coeff_path, coeff_size, coeff_mtime_ns, coeff_sha256) = match coeff {
+            Some((path, sha256)) => {
+                let canonical = path.canonicalize().with_context(|| {
+                    format!("Failed to canonicalize --ls-progress-coeff {}", path.display())
+                })?;
+                ensure_marker_safe_path("--ls-progress-coeff", &canonical)?;
+                let (size, mtime_ns) = file_size_mtime_ns(&canonical)?;
+                (Some(canonical), Some(size), Some(mtime_ns), Some(sha256))
+            }
+            None => (None, None, None, None),
+        };
+        Ok(Self {
+            model_path,
+            model_size,
+            model_mtime_ns,
+            coeff_path,
+            coeff_size,
+            coeff_mtime_ns,
+            coeff_sha256,
+        })
+    }
+
+    /// 現物がロード時の識別情報から差し替わっていないかを stat で検証する
+    /// (係数は再ハッシュしない — sha はロード時の byte 列に固定済み)。差し替えを
+    /// 検出したら硬いエラーにする: ロード済み weight で評価を続けても、marker が
+    /// 指すファイルと実体が一致しなくなるため。
+    fn verify_unchanged(&self) -> Result<()> {
+        let (size, mtime_ns) = file_size_mtime_ns(&self.model_path)?;
+        if (size, mtime_ns) != (self.model_size, self.model_mtime_ns) {
+            anyhow::bail!(
+                "NNUE model {} changed while rescoring (loaded size {} / current size {size}); \
+                 the loaded weights no longer match the file on disk. Restart the run.",
+                self.model_path.display(),
+                self.model_size,
+            );
+        }
+        if let (Some(path), Some(c_size), Some(c_mtime)) =
+            (&self.coeff_path, self.coeff_size, self.coeff_mtime_ns)
+        {
+            let (size, mtime_ns) = file_size_mtime_ns(path)?;
+            if (size, mtime_ns) != (c_size, c_mtime) {
+                anyhow::bail!(
+                    "--ls-progress-coeff {} changed while rescoring; the loaded coefficients \
+                     no longer match the file on disk. Restart the run.",
+                    path.display()
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 /// NNUE 静的評価 score sidecar の同一性 fingerprint を構築する。
 ///
-/// model_* は NNUE ファイル (path / size / mtime)、nnue_* は出力スコアを変える
-/// routing (`--ls-bucket-mode` / `--ls-progress-buckets` / `--ls-progress-coeff`
-/// の path + sha256) とスケール変換 (`--source-fv-scale` / `--target-fv-scale`)。
-/// `eval_scale_bits` / `onnx_draw_ply` は ONNX 専用キーだが marker format 上
-/// 必須のため固定値 (0) を書く。
+/// model_* / nnue_ls_progress_coeff_* はロード時に固定した [`NnueScoresIdentity`]
+/// から取り、入力 (path / size / mtime) だけを都度 stat する。nnue_* の残りは
+/// 出力スコアを変える routing (`--ls-bucket-mode` / `--ls-progress-buckets`) と
+/// スケール変換 (`--source-fv-scale` / `--target-fv-scale`)。`eval_scale_bits` /
+/// `onnx_draw_ply` は ONNX 専用キーだが marker format 上必須のため固定値 (0) を書く。
 fn build_nnue_scores_fingerprint(
     cli: &Cli,
+    identity: &NnueScoresIdentity,
     input_path: &std::path::Path,
     process_count: u64,
 ) -> Result<RunFingerprint> {
-    let nnue = cli
-        .nnue
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("NNUE score sidecar mode requires --nnue"))?;
-    let model_path = nnue
-        .canonicalize()
-        .with_context(|| format!("Failed to canonicalize --nnue {}", nnue.display()))?;
-    ensure_marker_safe_path("--nnue", &model_path)?;
-    let (model_size, model_mtime_ns) = file_size_mtime_ns(&model_path)?;
     let input_path = input_path
         .canonicalize()
         .with_context(|| format!("Failed to canonicalize {}", input_path.display()))?;
     ensure_marker_safe_path("input", &input_path)?;
     let (input_size, input_mtime_ns) = file_size_mtime_ns(&input_path)?;
-    let (nnue_ls_progress_coeff_path, nnue_ls_progress_coeff_sha256) =
-        match cli.ls_progress_coeff.as_deref() {
-            Some(path) => {
-                let canonical = path.canonicalize().with_context(|| {
-                    format!("Failed to canonicalize --ls-progress-coeff {}", path.display())
-                })?;
-                ensure_marker_safe_path("--ls-progress-coeff", &canonical)?;
-                let bytes = fs::read(&canonical).with_context(|| {
-                    format!("Failed to read --ls-progress-coeff {}", canonical.display())
-                })?;
-                let sha256 = format!("{:x}", Sha256::digest(bytes));
-                (Some(canonical), Some(sha256))
-            }
-            None => (None, None),
-        };
     Ok(RunFingerprint {
         version: MARKER_VERSION,
         mode: "nnue-static".to_string(),
         model_kind: "nnue".to_string(),
-        model_path,
-        model_size,
-        model_mtime_ns,
+        model_path: identity.model_path.clone(),
+        model_size: identity.model_size,
+        model_mtime_ns: identity.model_mtime_ns,
         input_path,
         input_size,
         input_mtime_ns,
@@ -1419,8 +1507,8 @@ fn build_nnue_scores_fingerprint(
         qsearch_ls_progress_coeff_sha256: None,
         nnue_ls_bucket_mode: cli.ls_bucket_mode.clone(),
         nnue_ls_progress_buckets: cli.ls_progress_buckets,
-        nnue_ls_progress_coeff_path,
-        nnue_ls_progress_coeff_sha256,
+        nnue_ls_progress_coeff_path: identity.coeff_path.clone(),
+        nnue_ls_progress_coeff_sha256: identity.coeff_sha256.clone(),
         nnue_source_fv_scale: Some(cli.source_fv_scale),
         nnue_target_fv_scale: Some(cli.target_fv_scale),
         expand: false,
@@ -1441,11 +1529,12 @@ fn build_nnue_scores_fingerprint(
 /// [`process_file_nnue_scores`] 内の in-progress marker が担う。
 fn nnue_scores_marker_decide(
     cli: &Cli,
+    identity: &NnueScoresIdentity,
     input_path: &std::path::Path,
     output_path: &std::path::Path,
     process_count: u64,
 ) -> Result<bool> {
-    let current = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    let current = build_nnue_scores_fingerprint(cli, identity, input_path, process_count)?;
     ensure_safe_output_path(output_path, &current.input_path)?;
     let marker_path = marker_path_for(output_path);
     if marker_path.exists() {
@@ -1474,6 +1563,7 @@ fn nnue_scores_marker_decide(
 /// 再開に備える。
 fn process_file_nnue_scores(
     cli: &Cli,
+    identity: &NnueScoresIdentity,
     input_path: &PathBuf,
     output_path: &PathBuf,
     process_count: u64,
@@ -1486,6 +1576,7 @@ fn process_file_nnue_scores(
     let target_fv_scale = cli.target_fv_scale;
     run_nnue_scores_pipeline(
         cli,
+        identity,
         input_path,
         output_path,
         process_count,
@@ -1518,8 +1609,10 @@ fn process_file_nnue_scores(
 /// して、NNUE ロードなし・小 chunk での統合テスト (順序保存 / chunk 境界 /
 /// fail-closed / resume) を成立させる。marker / resume / 件数検証のセマンティクスは
 /// この関数が単一の実装である。
+#[allow(clippy::too_many_arguments)]
 fn run_nnue_scores_pipeline(
     cli: &Cli,
+    identity: &NnueScoresIdentity,
     input_path: &PathBuf,
     output_path: &PathBuf,
     process_count: u64,
@@ -1530,7 +1623,10 @@ fn run_nnue_scores_pipeline(
     const SCORE_RECORD_SIZE: u64 = 2;
     assert!(chunk_size >= 1, "chunk_size must be >= 1");
 
-    let start_fingerprint = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    // ロード済みモデルと disk 上の実体が処理開始時点で一致していることを確認する。
+    identity.verify_unchanged()?;
+    let start_fingerprint =
+        build_nnue_scores_fingerprint(cli, identity, input_path, process_count)?;
     prepare_in_progress_marker(output_path, &start_fingerprint, false)?
         .context("out_scores=true did not create an in-progress marker")?;
     let resume_count = prepare_resume_count(output_path, SCORE_RECORD_SIZE, true)?;
@@ -1629,7 +1725,11 @@ fn run_nnue_scores_pipeline(
         );
     }
 
-    let final_fingerprint = build_nnue_scores_fingerprint(cli, input_path, process_count)?;
+    // model / coeff の差し替えは identity の stat 検証で、入力の変化は fingerprint
+    // 再構築 (入力 stat のみ都度取得) の比較で、それぞれ `.done` 昇格前に検出する。
+    identity.verify_unchanged()?;
+    let final_fingerprint =
+        build_nnue_scores_fingerprint(cli, identity, input_path, process_count)?;
     reject_changed_sidecar_fingerprint(
         output_path,
         &start_fingerprint,
@@ -5493,6 +5593,55 @@ mod marker_tests {
         ProcessResult::Ok(doubled.to_bytes(), false)
     }
 
+    /// fingerprint のモデル識別情報はロード時に固定した [`NnueScoresIdentity`] から
+    /// 来る: 実ファイルを後から差し替えても fingerprint は変わらず、差し替え自体は
+    /// `verify_unchanged` が検出する。
+    #[test]
+    fn nnue_identity_is_fixed_at_capture_and_swap_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let nnue = dir.path().join("nn.bin");
+        std::fs::write(&nnue, b"model v1").unwrap();
+        let coeff = dir.path().join("progress.bin");
+        let coeff_bytes = b"coeff v1 bytes".to_vec();
+        std::fs::write(&coeff, &coeff_bytes).unwrap();
+        let loaded_sha = format!("{:x}", Sha256::digest(&coeff_bytes));
+
+        let input = dir.path().join("in.psv");
+        std::fs::write(&input, test_psv(1).to_bytes()).unwrap();
+        let out_dir = dir.path().join("scores");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let cli = Cli::try_parse_from([
+            "rescore_psv",
+            "--input",
+            input.to_str().unwrap(),
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+            "--nnue",
+            nnue.to_str().unwrap(),
+            "--ls-progress-coeff",
+            coeff.to_str().unwrap(),
+            "--out-scores",
+        ])
+        .unwrap();
+
+        let identity =
+            NnueScoresIdentity::capture(&nnue, Some((&coeff, loaded_sha.clone()))).unwrap();
+        identity.verify_unchanged().expect("unchanged files must verify");
+        let fp1 = build_nnue_scores_fingerprint(&cli, &identity, &input, 1).unwrap();
+        assert_eq!(fp1.model_size, 8, "size of the loaded model v1");
+        assert_eq!(fp1.nnue_ls_progress_coeff_sha256.as_deref(), Some(loaded_sha.as_str()));
+
+        // モデルと係数を別内容 (別サイズ) に差し替えても fingerprint は固定値のまま。
+        std::fs::write(&nnue, b"model v2 with a different size").unwrap();
+        std::fs::write(&coeff, b"swapped coefficients v2").unwrap();
+        let fp2 = build_nnue_scores_fingerprint(&cli, &identity, &input, 1).unwrap();
+        assert_eq!(fp1, fp2, "identity fields must not re-stat the files");
+
+        // 差し替えは stat 検証が硬いエラーで検出する。
+        let err = identity.verify_unchanged().expect_err("swapped model must be detected");
+        assert!(err.to_string().contains("changed while rescoring"), "{err}");
+    }
+
     /// [`run_nnue_scores_pipeline`] の統合テスト: 小 chunk で順序保存・chunk 境界・
     /// 最終端数・エラー chunk の fail-closed prefix・件数 resume を一気に固定する。
     #[test]
@@ -5523,6 +5672,7 @@ mod marker_tests {
             "--out-scores",
         ])
         .unwrap();
+        let identity = NnueScoresIdentity::capture(&nnue, None).unwrap();
         let mut expected = Vec::new();
         for i in 0..n {
             expected.extend_from_slice(&pipeline_input_score(i).wrapping_mul(2).to_le_bytes());
@@ -5534,6 +5684,7 @@ mod marker_tests {
         let input_pathbuf = input.clone();
         run_nnue_scores_pipeline(
             &cli,
+            &identity,
             &input_pathbuf,
             &output,
             n,
@@ -5561,6 +5712,7 @@ mod marker_tests {
         };
         let err = run_nnue_scores_pipeline(
             &cli,
+            &identity,
             &input_pathbuf,
             &output,
             n,
@@ -5579,6 +5731,7 @@ mod marker_tests {
         // から追記され、最終 sidecar は一気通貫実行と bit 一致して `.done` へ昇格する。
         run_nnue_scores_pipeline(
             &cli,
+            &identity,
             &input_pathbuf,
             &output,
             n,


### PR DESCRIPTION
## 概要

rescore_psv の LayerStacks routing 防御を強化し、`--out-scores` (i16 score sidecar) を NNUE 静的評価モードに開放する。

背景: progresskpabs の routing bucket 数は「格納数以下」でありさえすれば合法のため、9-bucket net に `--ls-progress-buckets 8` を渡すと**エラーなく全行が誤 routing の評価になる** (8 指定と 9 指定で出力 sha256 が不一致になることを実測で確認済み)。数十億行規模の教師 pool を無警告で汚染し得る footgun だった。

## 防御仕様

- `--ls-progress-buckets` の明示値が NNUE ファイルの格納 bucket 数と**不一致ならエラー** (explicit 必須ポリシー自体は不変)。エラーメッセージに格納値と回避手段を明示。
- 格納数より少ない routing で学習された旧世代 net (格納 9 / routing 8) の再評価は、新フラグ **`--allow-routing-buckets-mismatch`** で警告付きに許可。
- 検証は NNUE 静的評価経路と qsearch 葉ラベル経路の両方が通る単一の検証点に配置。

## `--out-scores` の NNUE 静的評価開放

- ONNX 経路専用だった marker/resume 機構 (`.in-progress` fingerprint / `.done` 昇格 / 件数ベース追記 / fail-closed) の feature gate を外して共用。
- fingerprint に NNUE identity (path/size/mtime) と routing 実効値 (`--ls-bucket-mode` / `--ls-progress-buckets` / `--ls-progress-coeff` の path + sha256)、`--source-fv-scale` / `--target-fv-scale` を追加 (`nnue_*` キー。旧 ONNX marker は不変・後方互換)。
- qsearch / search / engine / expand / `--skip-in-check` / `--limit` / `--delete-input` との併用 reject は現行維持 (行対応の不変条件)。
- 出力は ONNX 経路と同じ `<入力名>.scores.i16`。sidecar はフル PSV 出力の score 列 (offset 32..34) と bit 一致する。

## 検証

- テスト 27 本 (新規 4): 不一致拒否 / override 許可、`nnue_*` marker キーの round-trip と旧 marker 後方互換、**パイプライン統合テスト** (評価関数注入 + 小 chunk で順序保存・chunk 境界・最終端数・エラー chunk の fail-closed prefix・件数 resume を固定)
- 実 net E2E smoke (9-bucket LayerStacks net + 56 行 PSV): ①sidecar 生成 + `.done` 昇格 → ②再実行 skip → ③8 指定エラー → ④override 警告付き完走 → ⑤途中 truncate から resume して一気通貫実行と sha256 一致 → ⑥フル PSV 出力の score 列と bit 一致
- `cargo fmt` / `clippy --tests` (default / `--no-default-features --features nnue-arch` とも warnings 0) / `cargo test -p tools` 916 passed / `check-tracked-abs-paths.sh` OK
- 独立レビュー (Codex): APPROVE (low 1 件 = 統合テスト追加、対応済み)

docs (`crates/tools/docs/rescore_psv.md` / `rescore_psv-internals.md`) と CHANGELOG Unreleased を更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
