### PR TITLE
perf(nnue): NNUE 重み配列と共有重み mmap に Transparent Huge Page の madvise を追加

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator.rs
+++ b/crates/rshogi-core/src/nnue/accumulator.rs
@@ -12,6 +12,8 @@ use super::bona_piece::ExtBonaPiece;
 use super::constants::{NUM_REFRESH_TRIGGERS, TRANSFORMED_FEATURE_DIMENSIONS};
 use super::piece_list::PieceNumber;
 use crate::types::{Color, MAX_PLY, Square, Value};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::alloc::alloc;
 use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
@@ -204,9 +206,13 @@ impl<const N: usize> Default for AlignedI16<N> {
 /// キャッシュラインサイズ（64バイト）
 pub const CACHE_LINE_SIZE: usize = 64;
 
+/// Transparent Huge Page のサイズ（x86_64 / aarch64 Linux の 2MiB）
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const HUGEPAGE_SIZE: usize = 2 * 1024 * 1024;
+
 /// `AlignedBox` のメモリ backing 種別
 enum AlignedBoxBacking {
-    /// `alloc_zeroed` で確保した通常ヒープ。Drop で `dealloc`。
+    /// `new_zeroed` がグローバルアロケータで確保した通常ヒープ。Drop で `dealloc`。
     Heap(Layout),
     /// プロセス間共有メモリ（`mmap`）のマッピングを借用。Drop で `munmap`。
     /// ロード後は read-only として扱う（`DerefMut` は panic する）。
@@ -259,11 +265,39 @@ impl<T: Copy + Default> AlignedBox<T> {
             .checked_mul(len)
             .expect("AlignedBox::new_zeroed: size overflow");
         let align = CACHE_LINE_SIZE.max(std::mem::align_of::<T>());
+        // FT 重み級の大きな配列は THP 境界に置き madvise する。THP enabled=madvise の
+        // 環境では madvise 無しだと 4KiB ページのままになる。
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let use_hugepage = size >= HUGEPAGE_SIZE;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let align = if use_hugepage {
+            align.max(HUGEPAGE_SIZE)
+        } else {
+            align
+        };
 
         // SAFETY: align は 2 のべき乗で、size は align の倍数に切り上げられる
         let layout = Layout::from_size_align(size, align).expect("Invalid layout").pad_to_align();
 
-        // SAFETY: layout は有効、alloc_zeroed は失敗時に null を返す
+        // hugepage 経路では alloc → madvise → 手動ゼロ埋めの順にする。alloc_zeroed は
+        // 非既定 align では内部 memset で先に fault するため、ゼロ埋めより前にヒントを置く。
+        // SAFETY: layout は有効で size は非ゼロ (>= HUGEPAGE_SIZE)、alloc / alloc_zeroed は
+        // 失敗時に null を返す。write_bytes は alloc が返した layout.size() バイトの
+        // 確保範囲内への書込で、alloc_zeroed と同じ初期状態にする。
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let ptr = if use_hugepage {
+            unsafe {
+                let raw = alloc(layout);
+                if !raw.is_null() {
+                    libc::madvise(raw as *mut libc::c_void, layout.size(), libc::MADV_HUGEPAGE);
+                    std::ptr::write_bytes(raw, 0, layout.size());
+                }
+                raw as *mut T
+            }
+        } else {
+            unsafe { alloc_zeroed(layout) as *mut T }
+        };
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let ptr = unsafe { alloc_zeroed(layout) as *mut T };
         if ptr.is_null() {
             std::alloc::handle_alloc_error(layout);
@@ -319,7 +353,7 @@ impl<T> DerefMut for AlignedBox<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match &self.backing {
             AlignedBoxBacking::Heap(_) => {
-                // SAFETY: backing が Heap であることを確認済み。ptr は alloc_zeroed で
+                // SAFETY: backing が Heap であることを確認済み。ptr は new_zeroed が
                 // 確保した有効ポインタで、len 要素分を排他的に所有する。
                 unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
             }
@@ -339,7 +373,7 @@ impl<T> Drop for AlignedBox<T> {
         match &self.backing {
             AlignedBoxBacking::Heap(layout) => {
                 // SAFETY:
-                // - ptr は alloc_zeroed で確保したポインタ、layout は同じもの
+                // - ptr は new_zeroed が確保したポインタ、layout は確保時と同じもの
                 // - AlignedBox::new_zeroed は T: Copy + Default を要求する
                 // - Copy トレイトは Drop と排他的なので、T は Drop を実装できない
                 // - したがって drop_in_place は不要で、dealloc のみで安全

--- a/crates/rshogi-core/src/nnue/shared_weights.rs
+++ b/crates/rshogi-core/src/nnue/shared_weights.rs
@@ -337,6 +337,13 @@ mod linux {
             return None;
         }
 
+        // 初回書込 (fault) より前にヒントを置き、THP 割当を促す。ヒントのみで内容も
+        // アドレスも変わらないため失敗は無視する。
+        // SAFETY: base / total は上の mmap で得た領域そのもの。
+        unsafe {
+            libc::madvise(base, spec.total, libc::MADV_HUGEPAGE);
+        }
+
         // ヘッダと blob を書き込む。
         // SAFETY: base は total バイトの有効な書込可能マッピング先頭。ページアラインの
         // ため `*mut ShmHeader` として整列している。shm は zero-fill 済みのため


### PR DESCRIPTION
## 概要

NNUE 重み配列 (`AlignedBox::new_zeroed`) と Linux 共有重み (shm mmap) に Transparent Huge Page の
`madvise(MADV_HUGEPAGE)` を追加する。TT (`tt/alloc.rs`) と同じ扱い。値・計算は不変で、探索ノード数は
before/after で bit 一致 (1536-none、`go depth 18`、startpos 196512 / 2g2f、中盤局面 2801198 / 8d7d)。

- `AlignedBox::new_zeroed`: size ≥ 2MiB のとき 2MiB align + madvise。`alloc_zeroed` は非既定 align だと
  内部 memset で先に 4KiB page fault するため、alloc → madvise → 手動ゼロ埋めの順にした
- `shared_weights.rs`: creator 経路の mmap 直後 (書込前) に同 madvise。tmpfs/shmem の THP 設定が
  有効な環境でのみ効く (無効なら no-op)
- Windows / macOS / wasm は従来の `alloc_zeroed` 経路のまま

## 計測 (Zen3 5950X / AVX2、search_only_ab、10s × abba × rounds 3 × 4 局面、threads=1、CPU pin)

A/A 床 (静穏時): pooled ±0.1%、per-position ±0.3%。

| 条件 | edition | pooled cycles/node | per-position (4 局面) | instructions/node | cache-misses/node |
|---|---|---:|---|---:|---|
| 共有 off (`RSHOGI_NNUE_SHARED_WEIGHTS=0`) | 1536 | −0.73% | −1.64 / +0.18 / −1.06 / −0.45 | +0.04% | −7〜−14% |
| 同 replicate | 1536 | −0.94% | −1.39 / −0.35 / −1.36 / −0.71 | +0.07% | −9〜−15% |
| 共有 off | 3072 | −0.76% | −1.03 / +0.32 / −0.73 / −1.64 | −0.04% | −3〜−12% |
| 共有 on (既定、shmem THP なし) | 1536 | −0.41% | −0.70 / −0.55 / −0.04 / −0.33 | +0.01% | −0.2〜−1.6% |

instructions/node はフラットで cycles/node のみ下がる = 同計算量で miss (dTLB walk) が減っている。
AnonHugePages は候補側で +216 MiB (FT 重み分)。共有 on でも Finny cache 等の ≥2MiB 確保が対象になる
ため弱く効く。

## 備考

- Linux 既定 (共有 on) で FT 重み分まで効かせるには shmem THP (`shmem_enabled` / tmpfs `huge=`) が
  必要。運用側の判断
- Windows の `MEM_LARGE_PAGES` 化は別途
- Zen5 / AVX-512 機での追試は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUcKeHgKDSKMPhTJ4gkcEW
