### PR TITLE
feat(tools): 対局 driver に千日手・連続王手の自動終局と opt-in の評価値裁定を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ core 変更を公開する PR では `crates/rshogi-core/Cargo.toml` のバー�
 
 ## Unreleased
 
+### tournament: ルールによる自動終局
+
+- 千日手を 4 回同一局面で自動終局し、連続王手の千日手は王手側の反則負けとする。
+  共有 driver を使う SPSA にも適用する。
+- `--adjudicate-resign` / `--adjudicate-draw` に評価値裁定を追加（既定 off）。
+  千日手と引分裁定は通常の引分として WLD / pentanomial に算入する。
+- `analyze_selfplay` に全 result 行の終局理由分布と `max_moves` 到達率を追加した。
+
 ### rescore_psv: routing bucket 数の防御と NNUE score sidecar
 
 - `--ls-progress-buckets` が NNUE ファイルの格納 bucket 数と不一致の場合はエラーに

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -8,7 +8,7 @@
 
 | ツール | 説明 |
 |--------|------|
-| `tournament` | 複数エンジンの round-robin 並列トーナメント、error ペア再対局、SPRT 検定。`--seed` による matchup ごとの決定的な開始局面選択と seed 付き meta 出力に対応（[詳細](docs/tournament.md)） |
+| `tournament` | 複数エンジンの round-robin 並列トーナメント、error ペア再対局、SPRT 検定。`--seed` による matchup ごとの決定的な開始局面選択と seed 付き meta 出力、千日手の自動終局に対応（[詳細](docs/tournament.md)） |
 | `analyze_selfplay` | tournament 出力の世代別ペア集計・Elo/nElo 算出・SPRT post-hoc 判定（[詳細](docs/analyze_selfplay.md)） |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |

--- a/crates/tools/docs/analyze_selfplay.md
+++ b/crates/tools/docs/analyze_selfplay.md
@@ -37,3 +37,19 @@ Wald パラメータは `--sprt-nelo0` / `--sprt-nelo1` / `--sprt-alpha` /
 
 追加統計には `error局`、`errorペア`、`再試行ペア`、`枯渇ペア` を表示する。
 `枯渇ペア` が 1 以上なら、そのテストはインフラ障害により invalid である。
+
+## 終局理由
+
+「終局理由」には `reason` 別の件数と、入力ファイルを通じた全 result 行数に対する
+割合を表示する。error 局・再試行前の世代・重複行・未完了ペアの行も各 1 件として数える。
+これは終局状況の監視用であり、WLD / SPRT のペア除外条件は変わらない。
+`error` で始まる reason は `error` にまとめ、reason の無い旧ログは `unknown` とする。
+
+表示順は `resign`, `win`, `sennichite`, `sennichite_perpetual_check`,
+`adjudication_resign`, `adjudication_draw`, `max_moves`, `timeout`, `illegal_move`,
+`no_bestmove`, `error`、続いてその他の理由を辞書順とし、0 件は省略する。
+`max_moves 到達率` は 0 件でも別行で明示する。result 行の無い入力ではこのセクションは表示しない。
+`--json` では `extra.reasons` に `{ "理由": 件数 }` を出力する。
+
+`sennichite` / `adjudication_draw` / `max_moves` は通常の引分として、
+`sennichite_perpetual_check` / `adjudication_resign` は勝者の勝ちとして集計する。

--- a/crates/tools/docs/spsa_runbook.md
+++ b/crates/tools/docs/spsa_runbook.md
@@ -31,6 +31,10 @@ cargo run --release -p tools --bin generate_spsa_params -- \
 
 ## 3. SPSA実行
 
+対局 driver は開始局面を含む 4 回同一局面で千日手を自動終局する。
+通常は引分、連続王手の千日手は王手側の反則負けとして評価に算入する。
+SPSA では評価値による投了・引分裁定は無効。
+
 > 以下のコマンド例は **starting point** であり、最適値ではない。
 > `--total-pairs` は対象 param 数 × 50〜500 程度の幅で結果を見ながら増減
 > するのが基本。`--early-stop-*` 三点は閾値の運用実績がまだ無いため、

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -6,7 +6,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `tournament` | 複数エンジンの round-robin 並列トーナメント。error ペアを同条件で再対局し、`--seed` による matchup ごとの決定的な開始局面選択、seed 付き meta、JSONL 出力に対応（[詳細](tournament.md)） |
+| `tournament` | 複数エンジンの round-robin 並列トーナメント。error ペアを同条件で再対局し、`--seed` による matchup ごとの決定的な開始局面選択、seed 付き meta、JSONL 出力、千日手の自動終局に対応（[詳細](tournament.md)） |
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
@@ -87,7 +87,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `spsa` | SPSA チューナー。paired antithetic + stochastic rounding + 1 batch = 1 update のスケジュールで対局を回す。複数 seed の探索は `--seed` を変えた独立 run dir を別プロセスで並列実行する |
+| `spsa` | SPSA チューナー（対局は千日手を自動終局）。paired antithetic + stochastic rounding + 1 batch = 1 update のスケジュールで対局を回す。複数 seed の探索は `--seed` を変えた独立 run dir を別プロセスで並列実行する |
 | `generate_spsa_params` | SearchTuneParams から SPSA 用 .params ファイルを生成 |
 | `generate_net_spsa_params` | LayerStacks `.bin` を走査し、net 重み delta 用 SPSA `.params` を生成（[詳細](generate_net_spsa_params.md)） |
 | `apply_net_spsa_params` | SPSA の net 重み delta を LayerStacks `.bin` へ焼き込み、feature 非依存の読み戻し検証と SHA-256 report を行う（[詳細](apply_net_spsa_params.md)） |

--- a/crates/tools/docs/tournament.md
+++ b/crates/tools/docs/tournament.md
@@ -91,6 +91,10 @@ test エンジンが base より +5 nelo 以上強いかを有意水準 95% で�
   16 ply 相当）。連続回数は 34 手未満でも数え、mate score・条件外の cp・
   評価値欠落でリセットする。
 
+`lowerbound` / `upperbound` 付きの score は確定評価ではないため、投了・引分裁定の
+両方で評価値欠落と同様に連続回数をリセットする。move 行の `eval.score_bound` に
+`lowerbound` / `upperbound` を記録する（確定評価と旧ログでは省略）。
+
 各フラグの key はすべて必須で、`,` または空白区切りに対応する（値全体を引用符で囲む）。
 未知・重複 key はエラー。`movecount` は 1 以上、`score` は非負の i32、`movenumber` は
 非負の u32 とする。有効な設定は meta の `settings.adjudicate_resign` /

--- a/crates/tools/docs/tournament.md
+++ b/crates/tools/docs/tournament.md
@@ -66,9 +66,55 @@ test エンジンが base より +5 nelo 以上強いかを有意水準 95% で�
 | `--engine PATH` | (必須、2 つ以上) | エンジンバイナリパス。`--engine` の数だけエンジン登録される |
 | `--engine-label LABEL` | パスから自動生成 | エンジンラベル（`--engine` と同数・同順で指定）。同一パスを複数回指定する場合は区別のため必須 |
 | `--games N` | 100 | 各方向の対局数（双方向で 2×N 局/ペア） |
-| `--max-moves N` | 512 | 1 局の最大手数（超過で引き分け） |
+| `--max-moves N` | 512 | 1 局の最大手数（到達で引分）。真の長手数局のみ（千日手は自動終局） |
+| `--adjudicate-resign "movecount=3,score=600"` | off | 同一側の劣勢評価の連続による投了裁定 |
+| `--adjudicate-draw "movenumber=34,movecount=8,score=20"` | off | 両側を通じた均衡評価の連続による引分裁定。手数は ply |
 | `--concurrency N` | 1 | 並列対局数。1 対局は手番制で約 1 CPU スレッド消費 |
 | `--report-interval N` | 10 | N 局ごとに進捗を表示 |
+
+### ルールによる自動終局
+
+千日手は常時有効。同一局面（盤・手番・持駒、pass 使用時は両側の pass 権も）が
+4 回出現した時点で引分にする。開始局面を 1 回目と数え、開始局面ファイルの
+手順を適用した後の局面から履歴を保持する。1 回目から連続して王手をかけていた
+側があれば、その側の反則負け（連続王手の千日手）になる。
+
+評価値による裁定は **既定 off**。chess の閾値（600cp / 20cp 等）は将棋で未較正であり、
+有効化は保存済み棋譜で誤裁定率を測ってから行う。
+
+- `--adjudicate-resign "movecount=3,score=600"`: 着手側の自己視点評価が -600cp 以下の
+  着手を、同一側で 3 回連続するとその側の負け。相手の着手はカウントに含めない。
+  負の mate score は劣勢として数え、正の mate score・条件外の cp・評価値欠落でリセットする。
+- `--adjudicate-draw "movenumber=34,movecount=8,score=20"`: 両側を通じて絶対値 20cp 以下が
+  8 手連続し、対局内の手数が 34 手以上なら引分。`movenumber` と `movecount` はいずれも
+  将棋の手数（ply）であり、chess の full move ではない（fastchess の `movecount=8` は
+  16 ply 相当）。連続回数は 34 手未満でも数え、mate score・条件外の cp・
+  評価値欠落でリセットする。
+
+各フラグの key はすべて必須で、`,` または空白区切りに対応する（値全体を引用符で囲む）。
+未知・重複 key はエラー。`movecount` は 1 以上、`score` は非負の i32、`movenumber` は
+非負の u32 とする。有効な設定は meta の `settings.adjudicate_resign` /
+`settings.adjudicate_draw` に記録し、無効な設定は省略する。
+
+合法手の適用後に千日手 → 投了裁定 → 引分裁定の順に判定し、終局手も move 行に記録する。
+千日手・引分裁定・最大手数による引分は通常の引分として WLD / pentanomial に算入する。
+連続王手の千日手と投了裁定には勝者を記録する。
+
+結果 JSONL の `reason` は次のとおり。
+
+| reason | 意味 |
+|--------|------|
+| `resign` | エンジンの投了 |
+| `win` | エンジンの勝ち宣言 |
+| `sennichite` | 千日手による引分 |
+| `sennichite_perpetual_check` | 連続王手をかけた側の反則負け |
+| `adjudication_resign` | 評価値による投了裁定 |
+| `adjudication_draw` | 評価値による引分裁定 |
+| `max_moves` | 最大手数到達による引分 |
+| `timeout` | 時間切れ負け |
+| `illegal_move` | 不正な指し手による負け |
+| `no_bestmove` | bestmove 欠落による負け |
+| `error: ...` | ワーカー・エンジン等のエラー（再対局対象） |
 
 ### 時間・エンジン設定
 

--- a/crates/tools/src/bin/analyze_selfplay.rs
+++ b/crates/tools/src/bin/analyze_selfplay.rs
@@ -103,6 +103,8 @@ struct EngineCommandMeta {
 /// 通常JSONLのresult行
 #[derive(Clone, Deserialize)]
 struct ResultLog {
+    #[serde(default)]
+    reason: Option<String>,
     outcome: String,
     /// 勝者のエンジンラベル（tournament.rs が出力、旧形式では None）
     #[serde(default)]
@@ -242,6 +244,7 @@ struct HeadToHeadStats {
 
 #[derive(Default)]
 struct FileExtraStats {
+    reasons: BTreeMap<String, u32>,
     total_plies: u64,
     completed_games: u32,
     black_wins: u32,
@@ -349,6 +352,7 @@ struct MoveBucketStats {
 
 #[derive(Default)]
 struct AggregatedExtraStats {
+    reasons: BTreeMap<String, u32>,
     total_plies: u64,
     completed_games: u32,
     black_wins: u32,
@@ -415,6 +419,7 @@ struct JsonHeadToHead {
 
 #[derive(Serialize)]
 struct JsonExtra {
+    reasons: BTreeMap<String, u32>,
     average_plies: f64,
     black_win_rate_decisive: f64,
     white_win_rate_decisive: f64,
@@ -642,6 +647,12 @@ fn parse_normal_file(path: &str) -> Result<FileResult> {
         } else if trimmed.contains("\"type\":\"result\"") {
             let result: ResultLog = serde_json::from_str(trimmed)
                 .with_context(|| format!("resultパースエラー: {path}"))?;
+            let reason = match result.reason.as_deref() {
+                Some(reason) if reason.starts_with("error") => "error",
+                Some(reason) => reason,
+                None => "unknown",
+            };
+            *stats.extra.reasons.entry(reason.to_string()).or_default() += 1;
             let pair_index = result.pair_index.unwrap_or(seq / 2);
             let slot = result.pair_slot.unwrap_or(seq % 2).min(1) as usize;
             seq += 1;
@@ -1231,6 +1242,9 @@ fn main() -> Result<()> {
                 stats.b_sente_wins += result.b_sente_wins;
                 engine_ids.insert(result.black);
                 engine_ids.insert(result.white);
+                for (reason, count) in result.extra.reasons {
+                    *extra.reasons.entry(reason).or_default() += count;
+                }
                 extra.total_plies += result.extra.total_plies;
                 extra.completed_games += result.extra.completed_games;
                 extra.black_wins += result.extra.black_wins;
@@ -1689,6 +1703,8 @@ fn print_text(
         }
     }
 
+    print_reasons(&extra.reasons);
+
     if extra.completed_games > 0 || extra.retry.error_games > 0 {
         println!();
         println!("追加統計");
@@ -1798,6 +1814,44 @@ fn print_text(
             }
         }
     }
+}
+
+const REASON_ORDER: [&str; 11] = [
+    "resign",
+    "win",
+    "sennichite",
+    "sennichite_perpetual_check",
+    "adjudication_resign",
+    "adjudication_draw",
+    "max_moves",
+    "timeout",
+    "illegal_move",
+    "no_bestmove",
+    "error",
+];
+
+fn print_reasons(reasons: &BTreeMap<String, u32>) {
+    let total: u64 = reasons.values().map(|&count| u64::from(count)).sum();
+    if total == 0 {
+        return;
+    }
+    println!("\n終局理由（全 result 行: {total}、error 局・重複行を含む）");
+    let ordered = REASON_ORDER.into_iter().chain(
+        reasons
+            .keys()
+            .map(String::as_str)
+            .filter(|reason| !REASON_ORDER.contains(reason)),
+    );
+    for reason in ordered {
+        if let Some(&count) = reasons.get(reason).filter(|&&count| count > 0) {
+            println!("  {reason}: {count} ({:.2}%)", f64::from(count) / total as f64 * 100.0);
+        }
+    }
+    let max_moves = reasons.get("max_moves").copied().unwrap_or(0);
+    println!(
+        "  max_moves 到達率: {:.2}% ({max_moves}/{total})",
+        f64::from(max_moves) / total as f64 * 100.0
+    );
 }
 
 fn win_rate(wins: u32, losses: u32, draws: u32) -> f64 {
@@ -1952,6 +2006,7 @@ fn print_json(
         engines: json_engines,
         head_to_head: json_h2h,
         extra: JsonExtra {
+            reasons: extra.reasons.clone(),
             average_plies: if extra.completed_games > 0 {
                 extra.total_plies as f64 / extra.completed_games as f64
             } else {
@@ -2219,6 +2274,46 @@ mod tests {
             },
             "live SPRT と同じ世代入力は retry 世代の WW 1 ペアだけになる"
         );
+    }
+
+    #[test]
+    fn reasons_count_all_results_without_changing_wld_or_penta() {
+        let (dir, path) = write_retry_log(&[
+            r#"{"type":"result","outcome":"draw","reason":"sennichite"}"#,
+            r#"{"type":"result","outcome":"white_win","winner":"test","reason":"sennichite_perpetual_check"}"#,
+            r#"{"type":"result","outcome":"draw","reason":"max_moves"}"#,
+            r#"{"type":"result","outcome":"draw","reason":"adjudication_draw"}"#,
+            r#"{"type":"result","outcome":"black_win","winner":"base","reason":"adjudication_resign"}"#,
+            r#"{"type":"result","outcome":"draw"}"#,
+            r#"{"type":"result","outcome":"draw","reason":"error: worker panic","error":true}"#,
+            r#"{"type":"result","outcome":"draw","reason":"error: engine exit","error":true}"#,
+            r#"{"type":"result","outcome":"draw","reason":"max_moves","pair_index":0,"pair_slot":0}"#,
+        ]);
+        let parsed = parse_normal_file(&path).unwrap();
+        assert_eq!((parsed.black_wins, parsed.white_wins, parsed.draws), (1, 1, 4));
+        assert_eq!(parsed.done, 6);
+        assert_eq!(
+            parsed.extra.reasons,
+            BTreeMap::from([
+                ("sennichite".to_string(), 1),
+                ("sennichite_perpetual_check".to_string(), 1),
+                ("max_moves".to_string(), 2),
+                ("adjudication_draw".to_string(), 1),
+                ("adjudication_resign".to_string(), 1),
+                ("unknown".to_string(), 1),
+                ("error".to_string(), 2),
+            ])
+        );
+        assert_eq!(
+            collect_sprt_penta(&path, "base", "test").unwrap(),
+            Penta {
+                wd: 1,
+                dd: 1,
+                dl: 1,
+                ..Penta::ZERO
+            }
+        );
+        dir.close().unwrap();
     }
 
     #[test]

--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -3041,6 +3041,8 @@ fn main() -> Result<()> {
     };
 
     let game_cfg = GameConfig {
+        resign_rule: None,
+        draw_rule: None,
         max_moves: cli.max_moves,
         timeout_margin_ms: cli.timeout_margin_ms,
         pass_rights: None,

--- a/crates/tools/src/bin/tournament.rs
+++ b/crates/tools/src/bin/tournament.rs
@@ -66,6 +66,7 @@ use serde::{Deserialize, Serialize};
 use tools::selfplay::game::{GameConfig, MoveEvent, run_game};
 use tools::selfplay::time_control::TimeControl;
 use tools::selfplay::types::{EvalLog, side_label};
+use tools::selfplay::{DrawRule, ResignRule};
 use tools::selfplay::{
     EngineConfig, EngineProcess, GameOutcome, ParsedPosition, load_start_positions,
 };
@@ -137,6 +138,12 @@ struct Cli {
     /// Maximum plies per game
     #[arg(long, default_value_t = 512)]
     max_moves: u32,
+    /// 評価値による投了裁定 (movecount=3,score=600)。既定 off。
+    #[arg(long, value_parser = clap::value_parser!(ResignRule))]
+    adjudicate_resign: Option<ResignRule>,
+    /// 評価値による引分裁定 (movenumber=34,movecount=8,score=20)。手数は ply。
+    #[arg(long, value_parser = clap::value_parser!(DrawRule))]
+    adjudicate_draw: Option<DrawRule>,
 
     /// Output directory (required)
     #[arg(long)]
@@ -314,6 +321,10 @@ struct MetaSettings {
     games: u32,
     seed: u64,
     max_moves: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    adjudicate_resign: Option<ResignRule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    adjudicate_draw: Option<DrawRule>,
     byoyomi: u64,
     #[serde(skip_serializing_if = "is_zero_u64")]
     btime: u64,
@@ -661,6 +672,8 @@ struct WorkerConfig {
     threads: usize,
     hash_mb: u32,
     max_moves: u32,
+    adjudicate_resign: Option<ResignRule>,
+    adjudicate_draw: Option<DrawRule>,
     timeout_margin_ms: u64,
     byoyomi: u64,
     btime: u64,
@@ -684,6 +697,8 @@ fn worker_main(
         threads,
         hash_mb,
         max_moves,
+        adjudicate_resign,
+        adjudicate_draw,
         timeout_margin_ms,
         byoyomi,
         btime,
@@ -754,6 +769,8 @@ fn worker_main(
         let tc = TimeControl::new(btime, btime, binc, binc, byoyomi);
         let config = GameConfig {
             max_moves,
+            resign_rule: adjudicate_resign,
+            draw_rule: adjudicate_draw,
             timeout_margin_ms,
             pass_rights: None,
             go_depth,
@@ -840,6 +857,8 @@ struct SpawnCtx<'a> {
     threads: usize,
     hash_mb: u32,
     max_moves: u32,
+    adjudicate_resign: Option<ResignRule>,
+    adjudicate_draw: Option<DrawRule>,
     timeout_margin_ms: u64,
     byoyomi: u64,
     btime: u64,
@@ -865,6 +884,8 @@ fn spawn_worker(
         threads: ctx.threads,
         hash_mb: ctx.hash_mb,
         max_moves: ctx.max_moves,
+        adjudicate_resign: ctx.adjudicate_resign,
+        adjudicate_draw: ctx.adjudicate_draw,
         timeout_margin_ms: ctx.timeout_margin_ms,
         byoyomi: ctx.byoyomi,
         btime: ctx.btime,
@@ -1097,6 +1118,8 @@ fn main() -> Result<()> {
             games: cli.games * 2,
             seed,
             max_moves: cli.max_moves,
+            adjudicate_resign: cli.adjudicate_resign,
+            adjudicate_draw: cli.adjudicate_draw,
             byoyomi: cli.byoyomi,
             btime: cli.btime,
             binc: cli.binc,
@@ -1240,6 +1263,8 @@ fn main() -> Result<()> {
                     games: cli.games * 2, // 各方向 cli.games 局、双方向で合計
                     seed,
                     max_moves: cli.max_moves,
+                    adjudicate_resign: cli.adjudicate_resign,
+                    adjudicate_draw: cli.adjudicate_draw,
                     byoyomi: cli.byoyomi,
                     btime: cli.btime,
                     binc: cli.binc,
@@ -1286,6 +1311,8 @@ fn main() -> Result<()> {
         threads: cli.threads,
         hash_mb: cli.hash_mb,
         max_moves: cli.max_moves,
+        adjudicate_resign: cli.adjudicate_resign,
+        adjudicate_draw: cli.adjudicate_draw,
         timeout_margin_ms: cli.timeout_margin_ms,
         byoyomi: cli.byoyomi,
         btime: cli.btime,
@@ -2251,6 +2278,117 @@ fn ensure_node_coverage(
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
+
+    #[test]
+    fn adjudication_flags_parse_and_default_off() {
+        let args = [
+            "tournament",
+            "--engine",
+            "base",
+            "--engine",
+            "test",
+            "--out-dir",
+            "out",
+        ];
+        let cli = super::Cli::try_parse_from(args).unwrap();
+        assert_eq!(cli.adjudicate_resign, None);
+        assert_eq!(cli.adjudicate_draw, None);
+        for separator in [",", " "] {
+            let resign = ["movecount=3", "score=600"].join(separator);
+            let draw = ["movenumber=34", "movecount=8", "score=20"].join(separator);
+            let cli = super::Cli::try_parse_from(args.into_iter().chain([
+                "--adjudicate-resign",
+                resign.as_str(),
+                "--adjudicate-draw",
+                draw.as_str(),
+            ]))
+            .unwrap();
+            assert_eq!(
+                cli.adjudicate_resign,
+                Some(super::ResignRule {
+                    movecount: 3,
+                    score: 600
+                })
+            );
+            assert_eq!(
+                cli.adjudicate_draw,
+                Some(super::DrawRule {
+                    movenumber: 34,
+                    movecount: 8,
+                    score: 20
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn adjudication_flags_reject_invalid_fields() {
+        for (flag, value) in [
+            ("--adjudicate-resign", "movecount=3,score=600,unknown=1"),
+            ("--adjudicate-resign", "movecount=3"),
+            ("--adjudicate-resign", "score=600"),
+            ("--adjudicate-resign", "movecount=3,score=600,score=20"),
+            ("--adjudicate-resign", "movecount=0,score=600"),
+            ("--adjudicate-resign", "movecount=3,score=-1"),
+            ("--adjudicate-resign", "movecount=3,score=2147483648"),
+            ("--adjudicate-resign", "movecount=x,score=600"),
+            ("--adjudicate-resign", "movecount=3,score"),
+            ("--adjudicate-draw", "movenumber=34,movecount=8,score=20,unknown=1"),
+            ("--adjudicate-draw", "movecount=8,score=20"),
+            ("--adjudicate-draw", "movenumber=34,score=20"),
+            ("--adjudicate-draw", "movenumber=34,movecount=8"),
+            ("--adjudicate-draw", "movenumber=34,movecount=8,score=20,movenumber=40"),
+            ("--adjudicate-draw", "movenumber=34,movecount=0,score=20"),
+        ] {
+            assert!(
+                super::Cli::try_parse_from([
+                    "tournament",
+                    "--engine",
+                    "base",
+                    "--engine",
+                    "test",
+                    "--out-dir",
+                    "out",
+                    flag,
+                    value,
+                ])
+                .is_err(),
+                "{flag} {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn adjudication_meta_omits_disabled_rules() {
+        let mut settings = super::MetaSettings {
+            games: 2,
+            seed: 0,
+            max_moves: 512,
+            adjudicate_resign: None,
+            adjudicate_draw: None,
+            byoyomi: 100,
+            btime: 0,
+            binc: 0,
+            timeout_margin_ms: 0,
+            threads: 1,
+            hash_mb: 16,
+            depth: None,
+            nodes: None,
+        };
+        let json = serde_json::to_value(&settings).unwrap();
+        assert!(json.get("adjudicate_resign").is_none());
+        assert!(json.get("adjudicate_draw").is_none());
+        settings.adjudicate_resign = Some("movecount=3,score=600".parse().unwrap());
+        settings.adjudicate_draw = Some("movenumber=34,movecount=8,score=20".parse().unwrap());
+        let json = serde_json::to_value(&settings).unwrap();
+        assert_eq!(json["adjudicate_resign"], serde_json::json!({"movecount":3,"score":600}));
+        assert_eq!(
+            json["adjudicate_draw"],
+            serde_json::json!({"movenumber":34,"movecount":8,"score":20})
+        );
+    }
+
     use super::{
         ControlFile, MatchResult, SprtState, TicketSource, build_engine_usi_options,
         deterministic_startpos_index, ensure_node_coverage, resolve_engine_nodes, splitmix64,

--- a/crates/tools/src/selfplay/adjudication.rs
+++ b/crates/tools/src/selfplay/adjudication.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use rshogi_core::position::Position;
-use rshogi_core::types::Color;
+use rshogi_core::types::{Color, Hand, Piece, Square};
 use serde::Serialize;
 
 use super::{EvalLog, GameOutcome};
@@ -30,20 +30,35 @@ fn loss(side: Color, reason: &'static str) -> Verdict {
     }
 }
 
-fn position_key(pos: &Position) -> String {
-    let sfen = pos.to_sfen();
-    let board = sfen.rsplit_once(' ').map_or(sfen.as_str(), |(board, _)| board);
-    let rights = if pos.is_pass_rights_enabled() {
-        (pos.pass_rights(Color::Black), pos.pass_rights(Color::White))
-    } else {
-        (0, 0)
-    };
-    format!("{board} {} {}", rights.0, rights.1)
+// ハッシュ衝突時も盤・持駒を厳密比較する。キー自体にヒープ領域を持たない。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PositionKey {
+    board: [Piece; Square::NUM],
+    hands: [Hand; 2],
+    side: Color,
+    pass_rights: [u8; 2],
+}
+
+fn position_key(pos: &Position) -> PositionKey {
+    let mut board = [Piece::NONE; Square::NUM];
+    for sq in Square::all() {
+        board[sq.index()] = pos.piece_on(sq);
+    }
+    PositionKey {
+        board,
+        hands: [pos.hand(Color::Black), pos.hand(Color::White)],
+        side: pos.side_to_move(),
+        pass_rights: if pos.is_pass_rights_enabled() {
+            [pos.pass_rights(Color::Black), pos.pass_rights(Color::White)]
+        } else {
+            [0, 0]
+        },
+    }
 }
 
 /// 4 回同一局面と連続王手の千日手を判定する。
 pub struct RuleAdjudicator {
-    history: HashMap<String, (u32, u32)>,
+    history: HashMap<PositionKey, (u32, u32)>,
     check_streak: [u32; 2],
 }
 
@@ -184,6 +199,8 @@ impl ScoreAdjudicator {
         eval: Option<&EvalLog>,
         ply: u32,
     ) -> Option<Verdict> {
+        // bound は確定評価ではないため、欠落評価と同様に連続回数をリセットする。
+        let eval = eval.filter(|e| e.score_bound.is_none());
         if let Some(rule) = self.resign {
             let losing = eval.is_some_and(|e| match e.score_mate {
                 Some(mate) => mate < 0,
@@ -249,6 +266,30 @@ mod tests {
     }
 
     const HIRATE: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+    /// キー生成のみの比較。対局全体の速度向上を表す測定ではない。
+    /// `cargo test -p tools --lib benchmark_position_key -- --ignored --nocapture`
+    /// 2026-09-09、test profile、10万回の ABBA: SFEN 129.48/129.72ms、固定長 3.17/3.12ms。
+    #[test]
+    #[ignore = "手動性能測定: --ignored --nocapture"]
+    fn benchmark_position_key() {
+        use std::hint::black_box;
+        use std::time::Instant;
+        let pos = position(HIRATE);
+        for fixed in [false, true, true, false] {
+            let start = Instant::now();
+            for _ in 0..100_000 {
+                if fixed {
+                    black_box(position_key(black_box(&pos)));
+                } else {
+                    let sfen = black_box(&pos).to_sfen();
+                    let board = sfen.rsplit_once(' ').unwrap().0;
+                    black_box(format!("{board} 0 0"));
+                }
+            }
+            eprintln!("fixed={fixed}: {:?} / 100000 keys", start.elapsed());
+        }
+    }
 
     #[test]
     fn fourth_occurrence_includes_start_position() {
@@ -446,6 +487,33 @@ mod tests {
                 GameOutcome::Draw,
                 "adjudication_draw",
             );
+        }
+    }
+
+    #[test]
+    fn bound_scores_reset_adjudication_streaks_through_usi_parser() {
+        for token in ["lowerbound", "upperbound"] {
+            for score in ["cp -700", "mate -3", "cp 0"] {
+                let mut snap = super::super::InfoSnapshot::default();
+                snap.update_from_line(&format!("info score {score} {token} pv 7g7f"));
+                let eval = snap.into_eval_log();
+                let mut scores = ScoreAdjudicator::new(
+                    Some(ResignRule {
+                        movecount: 2,
+                        score: 600,
+                    }),
+                    Some(DrawRule {
+                        movenumber: 0,
+                        movecount: 2,
+                        score: 20,
+                    }),
+                );
+                let exact = if score == "cp 0" { cp(0) } else { cp(-700) };
+                assert!(scores.after_move(Color::Black, Some(&exact), 1).is_none());
+                assert!(scores.after_move(Color::Black, eval.as_ref(), 3).is_none());
+                assert!(scores.after_move(Color::Black, Some(&exact), 5).is_none());
+                assert!(scores.after_move(Color::Black, Some(&exact), 7).is_some());
+            }
         }
     }
 

--- a/crates/tools/src/selfplay/adjudication.rs
+++ b/crates/tools/src/selfplay/adjudication.rs
@@ -1,0 +1,475 @@
+//! 対局履歴と評価値による終局裁定。
+//! core の反復判定は探索用で 2 回目を引分とし、遡りも plies_from_null.min(16) に制限される。
+//! ply も探索 root 基準なので、対局の 4 回同一局面判定には再利用しない。
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use rshogi_core::position::Position;
+use rshogi_core::types::Color;
+use serde::Serialize;
+
+use super::{EvalLog, GameOutcome};
+
+/// 裁定による勝敗と終局理由。
+pub struct Verdict {
+    /// 対局の勝敗。
+    pub outcome: GameOutcome,
+    /// JSONL に記録する終局理由。
+    pub reason: &'static str,
+}
+
+fn loss(side: Color, reason: &'static str) -> Verdict {
+    Verdict {
+        outcome: if side == Color::Black {
+            GameOutcome::WhiteWin
+        } else {
+            GameOutcome::BlackWin
+        },
+        reason,
+    }
+}
+
+fn position_key(pos: &Position) -> String {
+    let sfen = pos.to_sfen();
+    let board = sfen.rsplit_once(' ').map_or(sfen.as_str(), |(board, _)| board);
+    let rights = if pos.is_pass_rights_enabled() {
+        (pos.pass_rights(Color::Black), pos.pass_rights(Color::White))
+    } else {
+        (0, 0)
+    };
+    format!("{board} {} {}", rights.0, rights.1)
+}
+
+/// 4 回同一局面と連続王手の千日手を判定する。
+pub struct RuleAdjudicator {
+    history: HashMap<String, (u32, u32)>,
+    check_streak: [u32; 2],
+}
+
+impl RuleAdjudicator {
+    /// 開始局面を対局内 ply=0 の 1 回目として登録する。
+    pub fn new(pos: &Position) -> Self {
+        Self {
+            history: HashMap::from([(position_key(pos), (0, 1))]),
+            check_streak: [0; 2],
+        }
+    }
+
+    /// 合法手適用後の局面を登録する。ply は開始局面からの手数、pass は非王手とする。
+    pub fn after_move(
+        &mut self,
+        pos: &Position,
+        mover: Color,
+        gives_check: bool,
+        ply: u32,
+    ) -> Option<Verdict> {
+        let streak = &mut self.check_streak[mover as usize];
+        *streak = if gives_check {
+            streak.saturating_add(1)
+        } else {
+            0
+        };
+        let (first, count) = self.history.entry(position_key(pos)).or_insert((ply, 0));
+        *count += 1;
+        if *count < 4 {
+            return None;
+        }
+        let moves_per_side = (ply - *first) / 2;
+        let side = pos.side_to_move();
+        for checker in [side, !side] {
+            if self.check_streak[checker as usize] >= moves_per_side {
+                return Some(loss(checker, "sennichite_perpetual_check"));
+            }
+        }
+        Some(Verdict {
+            outcome: GameOutcome::Draw,
+            reason: "sennichite",
+        })
+    }
+}
+
+/// 自己視点の劣勢評価が同一側で連続した場合の投了裁定。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ResignRule {
+    /// 必要な同一側の連続着手数（1 以上）。
+    pub movecount: u32,
+    /// 劣勢評価の絶対閾値（非負の cp）。
+    pub score: i32,
+}
+
+/// 両側を通じて均衡評価が連続した場合の引分裁定。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct DrawRule {
+    /// 裁定を許可する対局内の手数（ply）。
+    pub movenumber: u32,
+    /// 必要な連続着手数（1 以上、両側を通算）。
+    pub movecount: u32,
+    /// 均衡評価の絶対閾値（非負の cp）。
+    pub score: i32,
+}
+
+fn parse_fields<const N: usize>(input: &str, keys: [&str; N]) -> Result<[u32; N], String> {
+    let mut values = [None; N];
+    for field in input.split(|c: char| c == ',' || c.is_whitespace()).filter(|s| !s.is_empty()) {
+        let (key, value) =
+            field.split_once('=').ok_or_else(|| format!("key=value が必要です: {field}"))?;
+        let index = keys
+            .iter()
+            .position(|k| *k == key)
+            .ok_or_else(|| format!("未知の key: {key}"))?;
+        if values[index].is_some() {
+            return Err(format!("重複した key: {key}"));
+        }
+        let value = value.parse::<u32>().map_err(|_| format!("非負の整数が必要です: {field}"))?;
+        if (key == "movecount" && value == 0) || (key == "score" && value > i32::MAX as u32) {
+            return Err(format!("値が範囲外です: {field}"));
+        }
+        values[index] = Some(value);
+    }
+    let mut result = [0; N];
+    for (index, value) in values.into_iter().enumerate() {
+        result[index] = value.ok_or_else(|| format!("必須 key がありません: {}", keys[index]))?;
+    }
+    Ok(result)
+}
+
+impl FromStr for ResignRule {
+    type Err = String;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let [movecount, score] = parse_fields(input, ["movecount", "score"])?;
+        Ok(Self {
+            movecount,
+            score: score as i32,
+        })
+    }
+}
+
+impl FromStr for DrawRule {
+    type Err = String;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let [movenumber, movecount, score] =
+            parse_fields(input, ["movenumber", "movecount", "score"])?;
+        Ok(Self {
+            movenumber,
+            movecount,
+            score: score as i32,
+        })
+    }
+}
+
+/// オプトインの評価値裁定。投了、引分の順に判定する。
+pub struct ScoreAdjudicator {
+    resign: Option<ResignRule>,
+    draw: Option<DrawRule>,
+    resign_streak: [u32; 2],
+    draw_streak: u32,
+}
+
+impl ScoreAdjudicator {
+    /// None のルールは無効にする。
+    pub fn new(resign: Option<ResignRule>, draw: Option<DrawRule>) -> Self {
+        Self {
+            resign,
+            draw,
+            resign_streak: [0; 2],
+            draw_streak: 0,
+        }
+    }
+
+    /// 合法手の自己視点評価を記録する。ply は開始局面からの将棋の手数。
+    pub fn after_move(
+        &mut self,
+        mover: Color,
+        eval: Option<&EvalLog>,
+        ply: u32,
+    ) -> Option<Verdict> {
+        if let Some(rule) = self.resign {
+            let losing = eval.is_some_and(|e| match e.score_mate {
+                Some(mate) => mate < 0,
+                None => e.score_cp.is_some_and(|cp| i64::from(cp) <= -i64::from(rule.score)),
+            });
+            let streak = &mut self.resign_streak[mover as usize];
+            *streak = if losing { streak.saturating_add(1) } else { 0 };
+            if *streak >= rule.movecount {
+                return Some(loss(mover, "adjudication_resign"));
+            }
+        }
+        if let Some(rule) = self.draw {
+            let balanced = eval.is_some_and(|e| {
+                e.score_mate.is_none()
+                    && e.score_cp.is_some_and(|cp| i64::from(cp).abs() <= i64::from(rule.score))
+            });
+            self.draw_streak = if balanced {
+                self.draw_streak.saturating_add(1)
+            } else {
+                0
+            };
+            if ply >= rule.movenumber && self.draw_streak >= rule.movecount {
+                return Some(Verdict {
+                    outcome: GameOutcome::Draw,
+                    reason: "adjudication_draw",
+                });
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rshogi_core::movegen::is_legal_with_pass;
+    use rshogi_core::types::Move;
+
+    fn position(sfen: &str) -> Position {
+        let mut pos = Position::new();
+        pos.set_sfen(sfen).unwrap();
+        pos
+    }
+
+    fn play(
+        pos: &mut Position,
+        rules: &mut RuleAdjudicator,
+        usi: &str,
+        ply: u32,
+    ) -> Option<Verdict> {
+        let mv = Move::from_usi(usi).unwrap();
+        assert!(is_legal_with_pass(pos, mv), "{usi}");
+        let mover = pos.side_to_move();
+        let check = !mv.is_pass() && pos.gives_check(mv);
+        pos.do_move(mv, check);
+        rules.after_move(pos, mover, check, ply)
+    }
+
+    fn assert_verdict(verdict: Option<Verdict>, outcome: GameOutcome, reason: &str) {
+        let verdict = verdict.expect("裁定が必要");
+        assert_eq!(verdict.outcome.label(), outcome.label());
+        assert_eq!(verdict.reason, reason);
+    }
+
+    const HIRATE: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+    #[test]
+    fn fourth_occurrence_includes_start_position() {
+        let mut pos = position(HIRATE);
+        let mut rules = RuleAdjudicator::new(&pos);
+        for ply in 1..=12 {
+            let verdict = play(
+                &mut pos,
+                &mut rules,
+                ["3i4h", "7a6b", "4h3i", "6b7a"][(ply as usize - 1) % 4],
+                ply,
+            );
+            if ply < 12 {
+                assert!(verdict.is_none(), "ply={ply}");
+            } else {
+                assert_verdict(verdict, GameOutcome::Draw, "sennichite");
+            }
+        }
+    }
+
+    #[test]
+    fn perpetual_checker_loses_on_fourth_occurrence() {
+        let mut pos = position("4k4/9/9/9/9/9/9/9/4K4 b R 1");
+        let mut rules = RuleAdjudicator::new(&pos);
+        assert!(play(&mut pos, &mut rules, "R*5e", 1).is_none());
+        for ply in 2..=13 {
+            let verdict = play(
+                &mut pos,
+                &mut rules,
+                ["5a4a", "5e4e", "4a5a", "4e5e"][(ply as usize - 2) % 4],
+                ply,
+            );
+            if ply < 13 {
+                assert!(verdict.is_none(), "ply={ply}");
+            } else {
+                assert_verdict(verdict, GameOutcome::WhiteWin, "sennichite_perpetual_check");
+            }
+        }
+    }
+
+    #[test]
+    fn non_repeating_moves_do_not_end_game() {
+        let mut pos = position(HIRATE);
+        let mut rules = RuleAdjudicator::new(&pos);
+        for (index, usi) in ["7g7f", "3c3d", "2g2f", "8c8d", "2f2e", "8d8e"].into_iter().enumerate()
+        {
+            assert!(play(&mut pos, &mut rules, usi, index as u32 + 1).is_none());
+        }
+    }
+
+    #[test]
+    fn key_ignores_move_number_but_includes_board_turn_hands_and_pass_rights() {
+        let pos = position(HIRATE);
+        assert_eq!(position_key(&pos), position_key(&position(&HIRATE.replace(" 1", " 123"))));
+        for sfen in [
+            HIRATE.replace(" b ", " w "),
+            HIRATE.replace("PPPPPPPPP", "1PPPPPPPP"),
+        ] {
+            assert_ne!(position_key(&pos), position_key(&position(&sfen)));
+        }
+        let sparse = HIRATE.replace("PPPPPPPPP", "1PPPPPPPP");
+        assert_ne!(
+            position_key(&position(&sparse)),
+            position_key(&position(&sparse.replace(" - ", " P ")))
+        );
+        let mut pass_pos = position(HIRATE);
+        for (black, white) in [(1, 0), (0, 1)] {
+            pass_pos.enable_pass_rights(black, white);
+            assert_ne!(position_key(&pos), position_key(&pass_pos));
+        }
+        pass_pos.set_pass_rights_enabled(false);
+        assert_eq!(position_key(&pos), position_key(&pass_pos));
+    }
+
+    #[test]
+    fn pass_resets_check_streak_and_changes_position_identity() {
+        let mut pos = position(HIRATE);
+        pos.enable_pass_rights(4, 4);
+        let mut rules = RuleAdjudicator::new(&pos);
+        rules.check_streak = [10, 10];
+        for ply in 1..=8 {
+            assert!(play(&mut pos, &mut rules, "pass", ply).is_none());
+        }
+        assert_eq!(rules.check_streak, [0, 0]);
+    }
+
+    #[test]
+    fn both_checkers_tie_break_loses_side_to_move() {
+        let pos = position(HIRATE);
+        let mut rules = RuleAdjudicator::new(&pos);
+        rules.history.insert(position_key(&pos), (0, 3));
+        rules.check_streak = [6, 6];
+        assert_verdict(
+            rules.after_move(&pos, Color::White, true, 12),
+            GameOutcome::WhiteWin,
+            "sennichite_perpetual_check",
+        );
+    }
+
+    fn cp(value: i32) -> EvalLog {
+        EvalLog {
+            score_cp: Some(value),
+            ..EvalLog::default()
+        }
+    }
+    fn mate(value: i32) -> EvalLog {
+        EvalLog {
+            score_mate: Some(value),
+            ..EvalLog::default()
+        }
+    }
+    fn resign() -> ScoreAdjudicator {
+        ScoreAdjudicator::new(
+            Some(ResignRule {
+                movecount: 3,
+                score: 600,
+            }),
+            None,
+        )
+    }
+
+    #[test]
+    fn resign_counts_each_side_independently() {
+        for loser in [Color::Black, Color::White] {
+            let mut scores = resign();
+            for ply in 1..=5 {
+                let mover = if ply % 2 == 1 { loser } else { !loser };
+                let verdict = scores.after_move(mover, Some(&cp(-600)), ply);
+                if ply < 5 {
+                    assert!(verdict.is_none());
+                } else {
+                    assert_verdict(verdict, loss(loser, "").outcome, "adjudication_resign");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resign_resets_on_recovery_missing_score_and_positive_mate() {
+        for reset in [
+            Some(cp(-599)),
+            None,
+            Some(EvalLog::default()),
+            Some(mate(1)),
+        ] {
+            let mut scores = resign();
+            for ply in 1..=2 {
+                assert!(scores.after_move(Color::Black, Some(&cp(-700)), ply).is_none());
+            }
+            assert!(scores.after_move(Color::Black, reset.as_ref(), 3).is_none());
+            for ply in 4..=5 {
+                assert!(scores.after_move(Color::Black, Some(&mate(-1)), ply).is_none());
+            }
+            assert_verdict(
+                scores.after_move(Color::Black, Some(&mate(-1)), 6),
+                GameOutcome::WhiteWin,
+                "adjudication_resign",
+            );
+        }
+    }
+
+    #[test]
+    fn draw_counts_plies_and_resets_on_mate_missing_or_unbalanced_score() {
+        let rule = DrawRule {
+            movenumber: 6,
+            movecount: 3,
+            score: 20,
+        };
+        let mut scores = ScoreAdjudicator::new(None, Some(rule));
+        for ply in 1..6 {
+            assert!(scores.after_move(Color::Black, Some(&cp(0)), ply).is_none());
+        }
+        assert_verdict(
+            scores.after_move(Color::White, Some(&cp(0)), 6),
+            GameOutcome::Draw,
+            "adjudication_draw",
+        );
+        for reset in [
+            Some(mate(-1)),
+            Some(mate(1)),
+            Some(cp(21)),
+            Some(cp(i32::MIN)),
+            None,
+            Some(EvalLog::default()),
+        ] {
+            let mut scores = ScoreAdjudicator::new(None, Some(rule));
+            for ply in 6..8 {
+                assert!(scores.after_move(Color::Black, Some(&cp(20)), ply).is_none());
+            }
+            assert!(scores.after_move(Color::White, reset.as_ref(), 8).is_none());
+            assert!(scores.after_move(Color::Black, Some(&cp(-20)), 9).is_none());
+            assert!(scores.after_move(Color::White, Some(&cp(20)), 10).is_none());
+            assert_verdict(
+                scores.after_move(Color::Black, Some(&cp(0)), 11),
+                GameOutcome::Draw,
+                "adjudication_draw",
+            );
+        }
+    }
+
+    #[test]
+    fn score_rules_default_off_and_resign_precedes_draw() {
+        let mut scores = ScoreAdjudicator::new(None, None);
+        for ply in 1..=20 {
+            assert!(scores.after_move(Color::Black, Some(&mate(-1)), ply).is_none());
+        }
+        let mut scores = ScoreAdjudicator::new(
+            Some(ResignRule {
+                movecount: 1,
+                score: 0,
+            }),
+            Some(DrawRule {
+                movenumber: 0,
+                movecount: 1,
+                score: 20,
+            }),
+        );
+        assert_verdict(
+            scores.after_move(Color::Black, Some(&cp(0)), 1),
+            GameOutcome::WhiteWin,
+            "adjudication_resign",
+        );
+    }
+}

--- a/crates/tools/src/selfplay/backend.rs
+++ b/crates/tools/src/selfplay/backend.rs
@@ -196,6 +196,7 @@ impl SearchBackend for NativeBackend {
         let best_move_usi = best_move.map(|m| m.to_usi());
 
         let eval = Some(EvalLog {
+            score_bound: None,
             score_cp: if result.score.is_mate_score() {
                 None
             } else {

--- a/crates/tools/src/selfplay/game.rs
+++ b/crates/tools/src/selfplay/game.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rshogi_core::movegen::is_legal_with_pass;
 use rshogi_core::types::{Color, Move};
 
+use super::adjudication::{DrawRule, ResignRule, RuleAdjudicator, ScoreAdjudicator};
 use super::engine::EngineProcess;
 use super::position::{ParsedPosition, build_position};
 use super::time_control::TimeControl;
@@ -9,6 +10,10 @@ use super::types::{EvalLog, GameOutcome, InfoCallback, SearchRequest};
 
 /// ゲーム設定
 pub struct GameConfig {
+    /// 評価値による投了裁定。既定は無効。
+    pub resign_rule: Option<ResignRule>,
+    /// 評価値による引分裁定。既定は無効。
+    pub draw_rule: Option<DrawRule>,
     pub max_moves: u32,
     pub timeout_margin_ms: u64,
     /// パス権利の初期値 (先手, 後手)。None の場合はパス権なし。
@@ -65,6 +70,8 @@ pub fn run_game(
     let pass_black = config.pass_rights.map(|(b, _)| b);
     let pass_white = config.pass_rights.map(|(_, w)| w);
     let mut pos = build_position(start_pos, pass_black, pass_white)?;
+    let mut rules = RuleAdjudicator::new(&pos);
+    let mut scores = ScoreAdjudicator::new(config.resign_rule, config.draw_rule);
     let mut tc = tc;
     let mut outcome = GameOutcome::InProgress;
     let mut outcome_reason = "max_moves".to_string();
@@ -157,6 +164,14 @@ pub fn run_game(
                             pos.gives_check(mv)
                         };
                         pos.do_move(mv, gives_check);
+                        if let Some(verdict) = rules
+                            .after_move(&pos, side, gives_check, plies_played)
+                            .or_else(|| scores.after_move(side, eval_log.as_ref(), plies_played))
+                        {
+                            outcome = verdict.outcome;
+                            outcome_reason = verdict.reason.to_string();
+                            terminal = true;
+                        }
                         tc.update_after_move(side, search.elapsed_ms);
                         move_usi = mv_str.clone();
                         raw_move_usi = None;

--- a/crates/tools/src/selfplay/mod.rs
+++ b/crates/tools/src/selfplay/mod.rs
@@ -1,3 +1,4 @@
+pub mod adjudication;
 pub mod backend;
 pub mod engine;
 pub mod game;
@@ -20,3 +21,5 @@ pub use types::{
     EvalLog, GameOutcome, InfoCallback, InfoSnapshot, SearchOutcome, SearchRequest, TimeArgs,
     duration_to_millis, side_label,
 };
+
+pub use adjudication::{DrawRule, ResignRule};

--- a/crates/tools/src/selfplay/types.rs
+++ b/crates/tools/src/selfplay/types.rs
@@ -2,8 +2,21 @@ use rshogi_core::types::Color;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// USI score の上下界。None は確定評価を表す。
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScoreBound {
+    /// 真の評価は報告値以上。
+    Lowerbound,
+    /// 真の評価は報告値以下。
+    Upperbound,
+}
+
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct EvalLog {
+    /// 評価値の上下界。旧ログには存在しない。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score_bound: Option<ScoreBound>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score_cp: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,6 +50,8 @@ pub struct UsiMultiPvCandidate {
 
 #[derive(Default, Clone)]
 pub struct InfoSnapshot {
+    /// 最後の主 PV 評価値に付随する上下界。
+    pub score_bound: Option<ScoreBound>,
     pub score_cp: Option<i32>,
     pub score_mate: Option<i32>,
     pub depth: Option<u32>,
@@ -55,7 +70,8 @@ impl InfoSnapshot {
     /// - multipv=1 の情報はメインフィールドを更新する
     /// - 全 multipv の候補を `multipv_candidates` に蓄積する（同一 multipv は上書き）
     pub fn update_from_line(&mut self, line: &str) {
-        let tokens: Vec<&str> = line.split_whitespace().collect();
+        let tokens: Vec<&str> =
+            line.split_whitespace().take_while(|token| *token != "string").collect();
         if tokens.first().copied() != Some("info") {
             return;
         }
@@ -72,6 +88,8 @@ impl InfoSnapshot {
         }
 
         // score と pv を抽出（全 multipv 共通のパース）
+        let mut score_seen = false;
+        let mut score_bound = None;
         let mut score_cp: Option<i32> = None;
         let mut score_mate: Option<i32> = None;
         let mut depth: Option<u32> = None;
@@ -84,6 +102,8 @@ impl InfoSnapshot {
         let mut i = 1;
         while i < tokens.len() {
             match tokens[i] {
+                "lowerbound" => score_bound = Some(ScoreBound::Lowerbound),
+                "upperbound" => score_bound = Some(ScoreBound::Upperbound),
                 "depth" if i + 1 < tokens.len() => {
                     depth = tokens[i + 1].parse::<u32>().ok();
                     i += 1;
@@ -106,11 +126,13 @@ impl InfoSnapshot {
                 }
                 "score" if i + 2 < tokens.len() => match tokens[i + 1] {
                     "cp" => {
+                        score_seen = true;
                         score_cp = tokens[i + 2].parse::<i32>().ok();
                         score_mate = None;
                         i += 2;
                     }
                     "mate" => {
+                        score_seen = true;
                         score_mate = tokens[i + 2].parse::<i32>().ok();
                         score_cp = None;
                         i += 2;
@@ -147,7 +169,8 @@ impl InfoSnapshot {
             if nps.is_some() {
                 self.nps = nps;
             }
-            if score_cp.is_some() || score_mate.is_some() {
+            if score_seen {
+                self.score_bound = score_bound;
                 self.score_cp = score_cp;
                 self.score_mate = score_mate;
             }
@@ -187,6 +210,7 @@ impl InfoSnapshot {
             return None;
         }
         Some(EvalLog {
+            score_bound: self.score_bound,
             score_cp: self.score_cp,
             score_mate: self.score_mate,
             depth: self.depth,
@@ -269,6 +293,45 @@ pub type InfoCallback<'a> = dyn FnMut(&str, &SearchRequest<'_>) + 'a;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn score_bounds_follow_primary_score_and_survive_log_roundtrip() {
+        for (token, bound) in [
+            ("lowerbound", ScoreBound::Lowerbound),
+            ("upperbound", ScoreBound::Upperbound),
+        ] {
+            let mut snap = InfoSnapshot::default();
+            snap.update_from_line(&format!("info score cp 0 {token} pv 7g7f"));
+            snap.update_from_line("info nodes 100");
+            snap.update_from_line("info multipv 2 score cp 10 pv 2g2f");
+            snap.update_from_line("info string score cp 900");
+            assert_eq!(snap.score_cp, Some(0));
+            assert_eq!(snap.score_bound, Some(bound));
+            let log = snap.clone().into_eval_log().unwrap();
+            let json = serde_json::to_string(&log).unwrap();
+            let log: EvalLog = serde_json::from_str(&json).unwrap();
+            assert_eq!(log.score_bound, Some(bound));
+            snap.update_from_line("info score mate -3 pv 7g7f");
+            assert_eq!(snap.score_bound, None);
+            assert_eq!(snap.score_cp, None);
+            assert_eq!(snap.score_mate, Some(-3));
+        }
+        let old: EvalLog = serde_json::from_str(r#"{"score_cp":0}"#).unwrap();
+        assert_eq!(old.score_bound, None);
+        assert!(serde_json::to_value(old).unwrap().get("score_bound").is_none());
+    }
+
+    #[test]
+    fn unparsed_score_clears_previous_exact_evaluation() {
+        for score in ["mate +", "mate -", "cp invalid"] {
+            let mut snap = InfoSnapshot::default();
+            snap.update_from_line("info score cp 0 pv 7g7f");
+            snap.update_from_line(&format!("info score {score}"));
+            let eval = snap.into_eval_log().unwrap();
+            assert_eq!(eval.score_cp, None);
+            assert_eq!(eval.score_mate, None);
+        }
+    }
 
     #[test]
     fn info_snapshot_parses_primary_pv() {

--- a/crates/tools/tests/tournament_adjudication_integration.rs
+++ b/crates/tools/tests/tournament_adjudication_integration.rs
@@ -1,0 +1,123 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt as _;
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn driver_adjudicates_repetition_and_only_exact_scores() {
+    for (score, flag, rule, reason, plies) in [
+        (
+            "cp 0 lowerbound",
+            "--adjudicate-draw",
+            "movenumber=0,movecount=2,score=20",
+            "sennichite",
+            12,
+        ),
+        (
+            "cp 0 upperbound",
+            "--adjudicate-draw",
+            "movenumber=0,movecount=2,score=20",
+            "sennichite",
+            12,
+        ),
+        (
+            "cp -700 lowerbound",
+            "--adjudicate-resign",
+            "movecount=2,score=600",
+            "sennichite",
+            12,
+        ),
+        (
+            "cp -700 upperbound",
+            "--adjudicate-resign",
+            "movecount=2,score=600",
+            "sennichite",
+            12,
+        ),
+        (
+            "cp 0",
+            "--adjudicate-draw",
+            "movenumber=0,movecount=2,score=20",
+            "adjudication_draw",
+            2,
+        ),
+        (
+            "cp -700",
+            "--adjudicate-resign",
+            "movecount=2,score=600",
+            "adjudication_resign",
+            3,
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = dir.path().join("engine.sh");
+        // 平手から金を往復。position の手数から手を選び、色交換後も同じ手順を返す。
+        fs::write(
+            &engine,
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    usi) printf 'id name repetition\nusiok\n' ;;
+    isready) printf 'readyok\n' ;;
+    position*) for token in $line; do ply=$token; done ;;
+    go*)
+      case $((ply % 4)) in
+        1) move=3i4h ;; 2) move=7a6b ;; 3) move=4h3i ;; 0) move=6b7a ;;
+      esac
+      printf 'info score %s pv %s\nbestmove %s\n' "$TEST_SCORE" "$move" "$move"
+      ;;
+    quit) break ;;
+  esac
+done
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&engine, fs::Permissions::from_mode(0o755)).unwrap();
+        let out = dir.path().join("out");
+        let output = Command::new(env!("CARGO_BIN_EXE_tournament"))
+            .env("TEST_SCORE", score)
+            .args([
+                "--engine",
+                engine.to_str().unwrap(),
+                "--engine-label",
+                "a",
+                "--engine",
+                engine.to_str().unwrap(),
+                "--engine-label",
+                "b",
+                "--games",
+                "1",
+                "--nodes",
+                "1",
+                "--max-moves",
+                "16",
+                "--out-dir",
+                out.to_str().unwrap(),
+                flag,
+                rule,
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+        let jsonl = fs::read_to_string(out.join("a-vs-b.jsonl")).unwrap();
+        let rows: Vec<Value> = jsonl.lines().map(|s| serde_json::from_str(s).unwrap()).collect();
+        let results: Vec<_> = rows.iter().filter(|row| row["type"] == "result").collect();
+        assert_eq!(results.len(), 2);
+        for result in results {
+            assert_eq!(result["reason"], reason, "{score}: {result}");
+            assert_eq!(result["plies"], plies);
+            assert_eq!(
+                result["outcome"],
+                if reason == "adjudication_resign" {
+                    "white_win"
+                } else {
+                    "draw"
+                }
+            );
+        }
+        assert_eq!(rows.iter().filter(|row| row["type"] == "move").count(), plies as usize * 2);
+    }
+}


### PR DESCRIPTION
## Summary

- `tournament` / `spsa` が共有する `run_game` に将棋ルールの自動終局を実装した。fishtest の runner (fastchess) が反復 / 50 手ルールを自動的に引分終局し **通常の引分として WLD / pentanomial に算入する** のと同じ扱いにする (除外・error 扱いしない)。
- 従来は driver が engine に履歴なしの `position sfen` を送るため千日手を誰も認識せず、`reason: max_moves` (512 手) の 81〜86% が同型反復だった (2026-09-08 調査)。
- 千日手 (盤・手番・持駒・pass 権が同一の局面の 4 回目、開始局面込み) は Draw / reason `sennichite` (floodgate_record の解釈と互換)。連続王手の千日手は王手側の反則負け (reason `sennichite_perpetual_check`)。
- `--adjudicate-resign "movecount=3,score=600"` / `--adjudicate-draw "movenumber=34,movecount=8,score=20"` (fastchess 流の score 裁定) を **既定 off** で追加。将棋での閾値は未較正のため有効化は保存済み棋譜で誤裁定率を測ってから (別タスク)。単位は ply。meta.settings に記録。
- `analyze_selfplay` に終局理由分布 (全 result 行) と `max_moves` 到達率を追加 (テキスト / JSON)。WLD / SPRT の集計ロジックは不変。
- `max_moves` / `win` / `resign` / `timeout` / `illegal_move` / `no_bestmove` の経路は従来どおり。

## 設計判断

| 項目 | 選択 | 理由 |
|---|---|---|
| 千日手の検出主体 | driver 側で局面履歴を保持 (`selfplay/adjudication.rs`) | core の `RepetitionState` は探索用で 2 回目の出現で Draw を返し、遡りも `plies_from_null.min(16)` に制限されるため 4 回ルールに再利用できない |
| 局面 key | 固定長の盤上81升・両側持駒・手番・両側 pass 権 | ハッシュ衝突時も全フィールドを厳密比較し、キー生成時のヒープ確保を避ける |
| 連続王手の判定式 | 各側の連続王手着手数 `check_streak[c] >= (now - first) / 2` | 1 回目〜4 回目の間の自分の着手が全て王手だったことと同値。両側同時 (理論上のみ) は core の `do_move` 判定順に合わせ手番側の負け |
| score 裁定 | opt-in、既定 off | testing_policy の「adjudication は誤裁定率を測ってから、chess 閾値をそのまま持ち込まない」に従う |

## 関連

- rshogi-notes `rshogi/testing_policy.md` §6 (max_moves 別計数) / §6 千日手の扱い (2026-09-08 制定) / §7 (adjudication 未較正)
- 非スコープ: engine への履歴送信 (`position ... moves`) の変更、score 閾値の較正、engine 側の千日手処理

bound 付き score は JSONL の `eval.score_bound` に保持し、投了・引分裁定では欠落評価と同様に連続回数をリセットする。`info string` の自由文は解析せず、読めない score で以前の評価を再利用しない。

## Test plan

- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test -p tools` / `bash scripts/check-tracked-abs-paths.sh`
- [x] 単体テスト: 平手 4 手周期の往復で 8 手目 (3 回目) は続行・12 手目 (4 回目) で `sennichite` / 飛車の連続王手 (`4k4/9/9/9/9/9/9/9/4K4 b R 1`, `R*5e` 以後 4 手周期) で 13 手目に王手側の負け / 非反復手順は続行 / score 裁定の境界 (mate・eval 欠落・movenumber) / CLI parser (未知 key・欠落・重複・区切り) / analyze_selfplay の分布と WLD・pentanomial 不変
- [x] 修正後の `cargo test` / `cargo test -p tools` / `cargo clippy --fix --allow-dirty --tests` / fmt / 絶対パスチェック
- [x] 模擬 USI エンジンとの統合対局6条件: 上下界付き引分・投了評価は12手目の千日手まで続行、確定評価は2手目の引分・3手目の投了裁定。結果と終局手ログも確認
- [x] キー生成単体10万回の ABBA: SFEN 129.48/129.72ms、固定長 3.17/3.12ms（test profile、対局全体の速度改善率ではない）。再現: `cargo test -p tools --lib benchmark_position_key -- --ignored --nocapture`
- [x] local reviewer #1 (Codex 系) APPROVE
- [x] local reviewer #2 (Claude 系) APPROVE (Nit 3 件は反映済み)
- [ ] 実エンジンでの統合対局 (千日手が実際に `sennichite` で終局し max_moves 率が下がること) は merge 後の次回対局評価で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)