### PR TITLE
perf(search): EvalHash を静的評価入口に配線し同一局面の NNUE 再評価を skip

### DIFF
--- a/crates/rshogi-core/src/eval/eval_hash.rs
+++ b/crates/rshogi-core/src/eval/eval_hash.rs
@@ -119,15 +119,14 @@ pub fn set_eval_hash_enabled(enabled: bool) {
 /// ## 設計原理
 /// - `key_xor = key ^ score` として格納
 /// - 読み取り時に `key = key_xor ^ score` で復元
-/// - 競合状態で不整合な読み取りが発生した場合、XOR結果が元のkeyと一致しない
-/// - キー不一致はキャッシュミスとして扱われ、安全に無視される
+/// - 競合状態で片方だけ更新された torn read は、XOR 結果が元の key と一致せず
+///   実質的に検出される（キー不一致 = キャッシュミス扱い）
 ///
 /// ## Memory Ordering について
-/// Relaxed orderingを使用。これは以下の理由で安全：
-/// 1. キャッシュの正確性はXORエンコーディングで保証される
+/// Relaxed orderingを使用。これは以下の理由で許容できる：
+/// 1. torn read は XOR 照合でほぼ確実にキャッシュミスに落ちる
 /// 2. 競合時の「偽陰性」（キャッシュミス）は許容される
-/// 3. 「偽陽性」（誤ったデータを返す）は発生しない（キー検証で排除）
-/// 4. Stockfish/YaneuraOuも同様のアプローチを採用
+/// 3. Stockfish/YaneuraOuも同様のアプローチを採用
 ///
 /// Release/Acquireを使用しない理由：
 /// - x86_64では差がない（ハードウェアが強いメモリモデルを提供）
@@ -185,7 +184,8 @@ impl EvalHash {
     }
 
     pub fn probe(&self, key: u64) -> Option<i32> {
-        if self.table.is_empty() {
+        // key 0 は未書込 entry (0, 0) と区別できないため常に miss とする
+        if self.table.is_empty() || key == 0 {
             return None;
         }
         #[cfg(feature = "diagnostics")]
@@ -203,7 +203,7 @@ impl EvalHash {
     }
 
     pub fn store(&self, key: u64, score: i32) {
-        if self.table.is_empty() {
+        if self.table.is_empty() || key == 0 {
             return;
         }
         let idx = self.index(key);
@@ -211,6 +211,16 @@ impl EvalHash {
         // i32 → u32 → u64: 符号付き整数をビットパターンを保持したまま拡張
         // probe時に逆変換で元の値を復元する
         entry.store_pair(key, score as u32 as u64);
+    }
+
+    /// 全 entry を未書込状態に戻す（in-place。再確保しない）
+    ///
+    /// 評価設定 (EvalFile / FV_SCALE / bucket routing / MaterialLevel 等) の変更後に
+    /// 旧設定の評価値が key 一致で hit するのを防ぐため、TT クリアと同じ箇所で呼ぶ。
+    pub fn clear(&self) {
+        for entry in self.table.iter() {
+            entry.store_pair(0, 0);
+        }
     }
 
     pub fn prefetch(&self, key: u64) {
@@ -373,10 +383,19 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_hash_key_zero() {
-        // キー0でも正常動作
+    fn test_eval_hash_key_zero_never_hits() {
         let hash = EvalHash::new(1);
         hash.store(0, 42);
-        assert_eq!(hash.probe(0), Some(42));
+        assert_eq!(hash.probe(0), None);
+    }
+
+    #[test]
+    fn test_eval_hash_clear() {
+        let hash = EvalHash::new(1);
+        let key = 0x1234_5678_9ABC_DEF0;
+        hash.store(key, 77);
+        assert_eq!(hash.probe(key), Some(77));
+        hash.clear();
+        assert_eq!(hash.probe(key), None);
     }
 }

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1329,7 +1329,14 @@ impl SearchWorker {
             let is_capture = pos.is_capture(mv);
 
             // 探索
-            do_move_and_push(&mut self.state, pos, mv, gives_check, self.tt.as_ref());
+            do_move_and_push(
+                &mut self.state,
+                pos,
+                mv,
+                gives_check,
+                self.tt.as_ref(),
+                self.eval_hash.as_ref(),
+            );
             // nodes_before は do_move 後に取得
             // (root move 自身の do_move ノードを effort に含めない)
             let nodes_before = self.state.nodes;
@@ -1945,7 +1952,14 @@ impl SearchWorker {
             let is_capture = pos.is_capture(mv);
 
             // 探索
-            do_move_and_push(&mut self.state, pos, mv, gives_check, self.tt.as_ref());
+            do_move_and_push(
+                &mut self.state,
+                pos,
+                mv,
+                gives_check,
+                self.tt.as_ref(),
+                self.eval_hash.as_ref(),
+            );
             // nodes_before は do_move 後に取得
             // (root move 自身の do_move ノードを effort に含めない)
             let nodes_before = self.state.nodes;
@@ -2974,7 +2988,7 @@ impl SearchWorker {
 
             // 指し手を実行
             st.stack[ply as usize].current_move = mv;
-            do_move_and_push(st, pos, mv, gives_check, ctx.tt);
+            do_move_and_push(st, pos, mv, gives_check, ctx.tt, ctx.eval_hash);
             // YaneuraOu方式: ContHistKey/ContinuationHistoryを設定
             // ⚠ in_checkは親ノードの王手状態を使用（gives_checkではない）
             // PASS は to()/moved_piece_after() が未定義のため、null move と同様に扱う

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -800,6 +800,11 @@ impl Search {
         self.thread_pool.update_eval_hash(Arc::clone(&self.eval_hash));
     }
 
+    /// EvalHash を in-place でクリアする（worker と共有する Arc をそのまま使う）
+    pub fn clear_eval_hash(&self) {
+        self.eval_hash.clear();
+    }
+
     /// EvalHashへの参照を取得
     pub fn eval_hash(&self) -> Arc<EvalHash> {
         Arc::clone(&self.eval_hash)

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -13,7 +13,7 @@ use super::alpha_beta::{
 use super::history::{CORRECTION_HISTORY_SIZE, CorrectionHistory};
 #[cfg(feature = "use-lazy-evaluate")]
 use super::search_helpers::ensure_nnue_accumulator;
-use super::search_helpers::nnue_evaluate;
+use super::search_helpers::nnue_evaluate_cached;
 use super::stats::inc_stat_by_depth;
 #[cfg(feature = "tt-trace")]
 use super::tt_sanity::{
@@ -484,13 +484,13 @@ pub(super) fn compute_eval_context(
         }
         #[cfg(not(feature = "use-lazy-evaluate"))]
         {
-            // TT eval 再利用による type-1 collision 伝播を避けるため常に NNUE 再評価する。
-            unadjusted_static_eval = nnue_evaluate(st, pos);
+            // TT eval は type-1 collision が伝播しうるので再利用せず、EvalHash か NNUE から取る。
+            unadjusted_static_eval = nnue_evaluate_cached(st, ctx, pos);
         }
         unadjusted_static_eval
     } else {
-        // PVノード または TTミス/eval無効 → 常にNNUE評価
-        unadjusted_static_eval = nnue_evaluate(st, pos);
+        // PVノード または TTミス/eval無効 → EvalHash か NNUE から取る
+        unadjusted_static_eval = nnue_evaluate_cached(st, ctx, pos);
         unadjusted_static_eval
     };
 

--- a/crates/rshogi-core/src/search/pruning.rs
+++ b/crates/rshogi-core/src/search/pruning.rs
@@ -526,7 +526,7 @@ where
         let cont_hist_to = mv.to();
 
         st.stack[ply as usize].current_move = mv;
-        do_move_and_push(st, pos, mv, gives_check, ctx.tt);
+        do_move_and_push(st, pos, mv, gives_check, ctx.tt, ctx.eval_hash);
         set_cont_history_for_move(
             st,
             ctx,

--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -12,7 +12,7 @@ use super::eval_helpers::correction_value;
 use super::movepicker::piece_value;
 use super::search_helpers::{
     check_abort, clear_cont_history_for_null, cont_history_tables, do_move_and_push, nnue_evaluate,
-    nnue_pop, set_cont_history_for_move,
+    nnue_evaluate_cached, nnue_pop, set_cont_history_for_move,
 };
 use super::stats::{inc_stat, inc_stat_by_depth};
 #[cfg(feature = "tt-trace")]
@@ -245,7 +245,7 @@ pub(super) fn qsearch<const NT: u8>(
                 return mate_value;
             }
         }
-        unadjusted_static_eval = nnue_evaluate(st, pos);
+        unadjusted_static_eval = nnue_evaluate_cached(st, ctx, pos);
         unadjusted_static_eval
     };
 
@@ -464,7 +464,7 @@ pub(super) fn qsearch<const NT: u8>(
         // 実際に探索された手をカウント
         inc_stat!(st, qs_moves_searched);
 
-        do_move_and_push(st, pos, mv, gives_check, ctx.tt);
+        do_move_and_push(st, pos, mv, gives_check, ctx.tt, ctx.eval_hash);
 
         // PASS は to()/moved_piece_after() が未定義のため、null move と同様に扱う
         if mv.is_pass() {

--- a/crates/rshogi-core/src/search/search_helpers.rs
+++ b/crates/rshogi-core/src/search/search_helpers.rs
@@ -4,6 +4,7 @@
 
 use std::ptr::NonNull;
 
+use crate::eval::{EvalHash, eval_hash_enabled};
 #[cfg(feature = "use-lazy-evaluate")]
 use crate::nnue::ensure_accumulator_computed;
 #[cfg(feature = "layerstack-arch")]
@@ -139,6 +140,28 @@ pub(super) fn nnue_evaluate(st: &mut SearchState, pos: &Position) -> Value {
     evaluate_dispatch(pos, &mut st.nnue_stack, acc_cache)
 }
 
+/// EvalHash を介した NNUE 静的評価（YaneuraOu の `Eval::evaluate` 相当）
+///
+/// hit 時はアキュムレータを更新しない。後続ノードの `update_accumulator` は
+/// 未計算の祖先を遡って差分適用 / refresh するため、skip しても整合は保たれる。
+#[inline]
+pub(super) fn nnue_evaluate_cached(
+    st: &mut SearchState,
+    ctx: &SearchContext<'_>,
+    pos: &Position,
+) -> Value {
+    if !eval_hash_enabled() {
+        return nnue_evaluate(st, pos);
+    }
+    let key = pos.key();
+    if let Some(raw) = ctx.eval_hash.probe(key) {
+        return Value::new(raw);
+    }
+    let value = nnue_evaluate(st, pos);
+    ctx.eval_hash.store(key, value.raw());
+    value
+}
+
 /// NNUE アキュムレータを計算済みにする（評価値の計算はしない）
 ///
 /// `use-lazy-evaluate` 有効時のみ使用する。
@@ -164,8 +187,12 @@ pub(super) fn do_move_and_push<P: TtPrefetch>(
     mv: Move,
     gives_check: bool,
     prefetcher: &P,
+    eval_hash: &EvalHash,
 ) {
     let dirty_piece = pos.do_move_with_prefetch(mv, gives_check, prefetcher);
+    if eval_hash_enabled() {
+        eval_hash.prefetch(pos.key());
+    }
     st.nodes += 1;
     st.nnue_stack.push(dirty_piece);
 }

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -329,11 +329,13 @@ impl UsiEngine {
     }
 
     /// isreadyコマンド: 準備完了を通知
-    /// YaneuraOu準拠: isready 受信時にTTをクリアする
+    /// YaneuraOu準拠: isready 受信時にTTをクリアする。
+    /// setoption 後は必ず isready が来るので、評価設定変更で陳腐化した EvalHash もここで捨てる。
     fn cmd_isready(&mut self) -> Result<()> {
         self.wait_for_search();
         if let Some(search) = self.search.as_mut() {
             search.clear_tt();
+            search.clear_eval_hash();
         }
         self.maybe_load_spsa_params();
         // EvalFile の状態を確認し、必要なら NNUE をロード
@@ -1147,6 +1149,7 @@ impl UsiEngine {
 
         if let Some(search) = self.search.as_mut() {
             search.clear_tt();
+            search.clear_eval_hash();
             search.clear_histories(); // YaneuraOu準拠：履歴統計もクリア
         }
         self.position = Position::new();

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、error ペア再対局、SPRT 検定。`--seed` による matchup ごとの決定的な開始局面選択と seed 付き meta 出力に対応（[詳細](docs/tournament.md)） |
 | `analyze_selfplay` | tournament 出力の世代別ペア集計・Elo/nElo 算出・SPRT post-hoc 判定（[詳細](docs/analyze_selfplay.md)） |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、USI engine vs engine／NativeBackend、native LS progress 係数、`--keep-tt` による native TT・EvalHash・履歴の対局間保持、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換・`live-mirror --push` MONITOR2 着手通知付きリアルタイムミラー（[詳細](docs/floodgate_pipeline.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と出典 TSV を生成（[詳細](docs/nyugyoku_gensfen.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -137,7 +137,7 @@ TT/履歴が共有されるため棋力評価には不向きだが、教師局�
 | `--progress-buckets N` | (progresskpabs 時必須) | 学習時と同じ routing bucket 数 |
 | `--progress-file PATH` | (progresskpabs 時必須) | native LayerStacks 用 progresskpabs 係数ファイル |
 | `--fv-scale N` | 0（自動判定） | FV_SCALE オーバーライド（NativeBackend 専用）。arch 文字列の fv_scale が実際の学習スケールと食い違うネットで指定する。USI モードでは `--usi-option FV_SCALE=N` を使う |
-| `--keep-tt[=BOOL]` | false | TT を対局間で保持（実験用） |
+| `--keep-tt[=BOOL]` | false | NativeBackend では TT・EvalHash・履歴を対局間で保持。false ではすべてクリア（実験用） |
 | `--engine-path PATH` | (USI 時必須) | エンジンバイナリパス |
 | `--engine-path-black/white PATH` | — | 先後別エンジン |
 | `--engine-args ARG...` | — | エンジンに渡す追加引数 |
@@ -148,6 +148,11 @@ TT/履歴が共有されるため棋力評価には不向きだが、教師局�
 | `--minimum-thinking-time N` | — | MinimumThinkingTime USI オプション |
 | `--slowmover N` | — | SlowMover USI オプション |
 | `--ponder` | false | USI_Ponder を有効化 |
+
+USI backend では `--keep-tt=true` は `isready` のみ、false は `usinewgame` と
+`isready` を送信する。実際のキャッシュ保持は接続先エンジンに依存し、rshogi は
+`isready` でも TT・EvalHash をクリアするため、true でも両キャッシュは保持されない。
+EvalHash の保持は、評価キャッシュの利用が有効な場合にキャッシュのウォーム状態へ影響する。
 
 ### 開始局面
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。error ペアを同条件で再対局し、`--seed` による matchup ごとの決定的な開始局面選択、seed 付き meta、JSONL 出力に対応（[詳細](tournament.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、engine vs engine／NativeBackend、native LS progress 係数、`--keep-tt` による native TT・EvalHash・履歴の対局間保持、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを attempt 世代別に集計。勝率・Elo 差・NPS・error 件数等を表示（[詳細](analyze_selfplay.md)） |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -324,7 +324,8 @@ struct Cli {
     #[arg(long, default_value_t = 0)]
     fv_scale: i32,
 
-    /// 置換表を対局間で保持する（TT をクリアしない）。
+    /// NativeBackend の TT・EvalHash・履歴を対局間で保持する。
+    /// USI backend は isready のみ送信し、保持動作は接続先エンジンに依存する。
     /// tanuki- は毎対局クリアするため、デフォルト false。実験用。
     /// --keep-tt=true で有効化、--keep-tt=false で明示的に無効化。
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]

--- a/crates/tools/src/selfplay/backend.rs
+++ b/crates/tools/src/selfplay/backend.rs
@@ -84,8 +84,9 @@ pub struct SearchParams {
 pub trait SearchBackend {
     /// 新しい対局の準備
     ///
-    /// `keep_tt` が true の場合は置換表を保持する。
-    /// false の場合は置換表と履歴をクリアする。
+    /// NativeBackend は true で TT・EvalHash・履歴を保持し、false ですべてクリアする。
+    /// USI backend は true で isready、false で usinewgame + isready を送る。
+    /// キャッシュ保持は接続先に依存し、rshogi は isready でも TT・EvalHash をクリアする。
     fn prepare_game(&mut self, keep_tt: bool) -> Result<()>;
 
     /// 探索を実行して結果を返す
@@ -115,9 +116,9 @@ impl NativeBackend {
 impl SearchBackend for NativeBackend {
     fn prepare_game(&mut self, keep_tt: bool) -> Result<()> {
         if keep_tt {
-            // TT・履歴ともに保持（USI の sync_ready() と同等）
+            // TT・EvalHash・履歴を保持（USI backend の保持動作は接続先に依存）
         } else {
-            // TT・履歴ともにクリア（USI の usinewgame と同等）
+            // TT・EvalHash・履歴をクリア（rshogi USI の usinewgame と同等）
             self.engine.clear_tt();
             self.engine.clear_eval_hash();
             self.engine.clear_histories();

--- a/crates/tools/src/selfplay/backend.rs
+++ b/crates/tools/src/selfplay/backend.rs
@@ -119,6 +119,7 @@ impl SearchBackend for NativeBackend {
         } else {
             // TT・履歴ともにクリア（USI の usinewgame と同等）
             self.engine.clear_tt();
+            self.engine.clear_eval_hash();
             self.engine.clear_histories();
         }
         Ok(())


### PR DESCRIPTION
## 概要

`EvalHash` (16B entry、64bit key XOR エンコード、direct-mapped) は確保・配線済みだったが探索から一度も
参照されていなかった。YaneuraOu の `Eval::evaluate` と同型に、静的評価入口 3 箇所 (compute_eval_context の
2 箇所と qsearch) で probe → hit なら値を返す / miss なら NNUE 評価して store するよう配線し、do_move 直後に
TT prefetch と並べて EvalHash の prefetch を置く。

- hit 時は accumulator を更新しない。後続ノードの `update_accumulator` は未計算の祖先を遡って差分適用 /
  refresh するため整合は保たれる (i16 加減算なので経路によらず値は同一)
- `EvalHash::clear()` を追加し、TT クリアと同じ箇所 (rshogi-usi の isready / usinewgame、selfplay
  NativeBackend の prepare_game) で呼ぶ。setoption 後は必ず isready が来るので EvalFile / FV_SCALE /
  bucket routing / MaterialLevel 等の変更で陳腐化した値は捨てられる
- key 0 は未書込 entry (0, 0) と区別できないため probe / store の対象外にする
- `UseEvalHash=false` で従来どおり常時 NNUE 評価 (prefetch もしない)

## 探索結果の不変性

1536-none、`go depth 18`、4 局面 (startpos + 中盤 3 局面) で before / after / after+`UseEvalHash=false` の
score / seldepth / nodes / hashfull / PV / bestmove / ponder が完全一致 (startpos 196512 nodes / 2g2f 等)。
64bit key なので偽 hit は実質ゼロで、同一局面の再評価を skip するだけ。SPRT は行っていない。

事前計測 (diagnostics build) では静的評価の 30〜44% が hit し、その 99.9% 超は TT hit ノードで発生する。
つまり `use-lazy-evaluate` (TT eval 再利用、16bit key の type-1 collision で探索木が変わるため default off)
と同じ評価を、探索木を変えずに節約する。

## 計測 (Zen3 5950X / AVX2、search_only_ab、10s × abba × rounds 3 × 4 局面、threads=1、CPU pin、EvalHash=256)

A/A 床 (静穏時): pooled ±0.1%、per-position ±0.3%。

| edition | pooled cycles/node | per-position (4 局面) | instructions/node | L1d-miss/node | NPS |
|---|---:|---|---:|---:|---:|
| 1536 | −2.15% (再計測 −2.14%) | −4.73 / −1.17 / −0.77 / −1.82 | −5.58% | −21〜−32% | +2.4% |
| 3072 | −4.98% | −6.41 / −4.92 / −4.95 / −3.64 | −8.91% | −22〜−29% | +5.3% |

1 評価が重い 3072 ほど効き、1536/3072 の NPS 比は 0.700 → 0.720 に縮まる。

## 備考

- 既定 `EvalHash=256` (MB) はこれまでも確保されていたので RSS は変わらない。isready ごとに 256MB の
  clear が走る (TT と同様)
- Zen5 / AVX-512 機での追試は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUcKeHgKDSKMPhTJ4gkcEW
