### PR TITLE
fix(search): 初期化前のponderhit通知を保持する

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -2468,6 +2468,49 @@ mod tests {
     }
 
     #[test]
+    fn ponderhit_before_go_returns_bestmove_without_stop() {
+        let guard = crate::eval::material::test_support::lock_material();
+        crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+        let mut search = Search::new_with_eval_hash(1, 1);
+        search.reset_flags();
+        let stop = search.stop_flag();
+        let ponderhit = search.ponderhit_handle();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let search_barrier = Arc::clone(&barrier);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(move || {
+                let mut pos = Position::new();
+                pos.set_hirate();
+                search_barrier.wait();
+                let result = search.go(
+                    &mut pos,
+                    LimitsType {
+                        ponder: true,
+                        depth: 1,
+                        ..LimitsType::default()
+                    },
+                    None::<fn(&SearchInfo)>,
+                );
+                tx.send((result.best_move, search.ponderhit_flag_for_test())).unwrap();
+            })
+            .unwrap();
+        ponderhit.signal();
+        barrier.wait();
+        let result = rx.recv_timeout(Duration::from_secs(5));
+        // 回帰時にも探索スレッドを残さず、stop による返却を成功扱いしない。
+        if result.is_err() {
+            stop.store(true, Ordering::SeqCst);
+        }
+        worker.join().unwrap();
+        let (best_move, pending) = result.expect("ponderhit alone must release bestmove");
+        assert_ne!(best_move, Move::NONE);
+        assert!(!pending);
+        drop(guard);
+    }
+
+    #[test]
     fn ponderhit_handle_signals_search() {
         let search = Search::new_with_eval_hash(1, 1);
         let handle = search.ponderhit_handle();

--- a/crates/rshogi-core/src/search/time_manager.rs
+++ b/crates/rshogi-core/src/search/time_manager.rs
@@ -268,6 +268,8 @@ impl TimeManagement {
 
     /// 今回の思考時間を決定する
     ///
+    /// 共有通知は変更しない。stop / ponderhit のリセットは探索起動前に呼び出し元が行う。
+    ///
     /// # Arguments
     /// * `limits` - 探索制限
     /// * `us` - 自分の手番
@@ -279,7 +281,6 @@ impl TimeManagement {
         self.search_end = 0;
         self.is_final_push = false;
         self.is_pondering = limits.ponder;
-        self.ponderhit.store(false, Ordering::Relaxed);
         self.single_move_limit = false;
         self.stop_on_ponderhit = false;
         self.last_stop_threshold = None;
@@ -440,7 +441,9 @@ impl TimeManagement {
         }
     }
 
-    /// 今回の思考時間を決定する（合法手数を考慮）
+    /// 今回の思考時間を決定する
+    ///
+    /// 共有通知は変更しない。stop / ponderhit のリセットは探索起動前に呼び出し元が行う。（合法手数を考慮）
     ///
     /// # Arguments
     /// * `limits` - 探索制限
@@ -856,6 +859,45 @@ mod tests {
 
     fn create_time_manager() -> TimeManagement {
         TimeManagement::new(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)))
+    }
+
+    #[test]
+    fn test_init_preserves_ponderhit_before_main_and_helper_init() {
+        for helper_init in [false, true] {
+            let stop = Arc::new(AtomicBool::new(false));
+            let ponderhit = Arc::new(AtomicBool::new(false));
+            let limits = LimitsType {
+                ponder: true,
+                depth: 1,
+                ..LimitsType::default()
+            };
+            let mut main = TimeManagement::new(Arc::clone(&stop), Arc::clone(&ponderhit));
+            if helper_init {
+                main.init(&limits, Color::Black, 1, DEFAULT_MAX_MOVES_TO_DRAW);
+            }
+
+            let barrier = Arc::new(std::sync::Barrier::new(2));
+            let init_barrier = Arc::clone(&barrier);
+            let init_stop = Arc::clone(&stop);
+            let init_ponderhit = Arc::clone(&ponderhit);
+            let worker = std::thread::spawn(move || {
+                let mut tm = TimeManagement::new(init_stop, init_ponderhit);
+                init_barrier.wait();
+                tm.init(&limits, Color::Black, 1, DEFAULT_MAX_MOVES_TO_DRAW);
+                tm
+            });
+            // 通知を初期化より前に固定する。helper 側の場合は main の初期化後。
+            ponderhit.store(true, Ordering::SeqCst);
+            barrier.wait();
+            let initialized = worker.join().unwrap();
+            if !helper_init {
+                main = initialized;
+            }
+            assert!(main.take_ponderhit(), "init must preserve pending notification");
+            assert!(!main.take_ponderhit(), "notification is consumed exactly once");
+            main.on_ponderhit();
+            assert!(!main.is_pondering());
+        }
     }
 
     #[test]

--- a/crates/rshogi-usi/tests/usi_flow.rs
+++ b/crates/rshogi-usi/tests/usi_flow.rs
@@ -68,49 +68,51 @@ fn quit_outputs_bestmove() {
     assert!(output.status.success());
 }
 
-/// `go ponder`→`ponderhit`→`quit` で bestmove が返ること
-#[test]
-fn ponderhit_outputs_bestmove() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"));
-    let mut child = cmd
+/// bestmove を受信するまで quit/stop を送らず、通知だけで探索を終了できることを確認する。
+fn assert_ponderhit_returns_before_quit(stochastic: bool) {
+    use std::io::{BufRead, BufReader};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let mut child = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"))
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .spawn()
         .expect("spawn engine");
-
-    {
-        let stdin = child.stdin.as_mut().expect("stdin");
-        write!(stdin, "{USI_INIT}position startpos\ngo ponder depth 2\nponderhit\nquit\n")
-            .expect("write");
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let line = line.expect("read engine output");
+            if line.starts_with("bestmove ") {
+                tx.send(line).ok();
+            }
+        }
+    });
+    let stdin = child.stdin.as_mut().unwrap();
+    write!(stdin, "{USI_INIT}setoption name Stochastic_Ponder value {stochastic}\nposition startpos\ngo ponder depth 2\nponderhit\n").unwrap();
+    stdin.flush().unwrap();
+    let bestmove = rx.recv_timeout(Duration::from_secs(10));
+    if bestmove.is_err() {
+        child.kill().expect("terminate unresponsive engine");
+    } else {
+        writeln!(child.stdin.as_mut().unwrap(), "quit").unwrap();
     }
-
-    let output = child.wait_with_output().expect("wait output");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("bestmove"), "stdout:\n{stdout}");
-    assert!(output.status.success());
+    let status = child.wait().unwrap();
+    reader.join().unwrap();
+    let bestmove = bestmove.expect("ponderhit must return bestmove before quit/stop");
+    assert!(!bestmove.starts_with("bestmove resign"), "{bestmove}");
+    assert!(status.success());
 }
 
-/// `Stochastic_Ponder` 有効時の `ponderhit` で通常探索へ切り替わって bestmove が返ること
+/// 通常 ponder は共有通知の消費で bestmove を返す。
+#[test]
+fn ponderhit_outputs_bestmove() {
+    assert_ponderhit_returns_before_quit(false);
+}
+
+/// Stochastic_Ponder は先読みを停止し、通常探索へ切り替えて bestmove を返す。
 #[test]
 fn stochastic_ponderhit_restarts_search() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"));
-    let mut child = cmd
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn engine");
-
-    {
-        let stdin = child.stdin.as_mut().expect("stdin");
-        write!(
-            stdin,
-            "{USI_INIT}setoption name Stochastic_Ponder value true\nposition startpos\ngo ponder depth 2\nponderhit\nquit\n"
-        )
-        .expect("write");
-    }
-
-    let output = child.wait_with_output().expect("wait output");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("bestmove"), "stdout:\n{stdout}");
-    assert!(output.status.success());
+    assert_ponderhit_returns_before_quit(true);
 }


### PR DESCRIPTION
探索スレッドの初期化より先に通常の ponderhit が届くと、TimeManagement::init が共有通知を消し、bestmove を待つ側が停止する可能性がありました。helper の初期化も同じ通知を消していました。init ではローカルの時間管理状態だけを初期化し、共有通知のリセットは既存の探索起動前 reset_flags に任せます。

barrier で main/helper 初期化前の通知順序を固定し、通知を一度だけ消費できることを確認します。実 Search::go も事前通知だけで bestmove を返すことを検証し、元の reset を戻すと両回帰テストが失敗することを確認しました。USI テストは bestmove を受信してから quit するように変更し、quit による暗黙の停止で回帰が隠れないようにしています。

通常 ponder の通知処理と、Stochastic_Ponder の停止・再探索経路をそれぞれ検証しています。固定時間 ponder の期限問題（F02）には変更を加えていません。発生頻度・実対局での事故件数は未測定です。

根拠: [03-cache-smp F01](https://github.com/SH11235/rshogi-notes/blob/181aaa14c73aa4bf11b1c907a946a20d0c288a1e/rshogi/20260909-code-review-03-cache-smp-bec3b988-codex-0330/tasks.md)

検証:
- cargo fmt --all -- --check
- cargo clippy --fix --allow-dirty --tests
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- core ponderhit 関連12件（default / no-default-features + edition-universal）
- USI integration 5件（通常 ponder / Stochastic_Ponder を含む）
- bash scripts/check-tracked-abs-paths.sh
- 独立Codexレビュー2件