### PR TITLE
fix(tt): 共有 TT の UB を lockless な atomic 格納と借用付き writer で除去する

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -252,9 +252,9 @@ use super::stats::{inc_stat, inc_stat_by_depth};
 /// 置換表プローブの結果をまとめたコンテキスト
 ///
 /// TTプローブ後の即時カットオフ判定や、後続の枝刈りロジックで使用される。
-pub(super) struct TTContext {
+pub(super) struct TTContext<'a> {
     pub(super) key: u64,
-    pub(super) result: ProbeResult,
+    pub(super) result: ProbeResult<'a>,
     pub(super) data: TTData,
     pub(super) hit: bool,
     pub(super) mv: Move,
@@ -263,9 +263,9 @@ pub(super) struct TTContext {
 }
 
 /// 置換表プローブの結果（続行 or カットオフ）
-pub(super) enum ProbeOutcome {
+pub(super) enum ProbeOutcome<'a> {
     /// 探索続行（TTContext付き）
-    Continue(TTContext),
+    Continue(TTContext<'a>),
     /// 即時カットオフ値（ヒストリ更新用情報付き）
     Cutoff {
         value: Value,
@@ -1197,7 +1197,8 @@ impl SearchWorker {
 
         // ルートでもTTプローブを行う
         let key = pos.key();
-        let tt_result = self.tt.probe(key, pos);
+        let tt = Arc::clone(&self.tt);
+        let tt_result = tt.probe(key, pos);
         let tt_hit = tt_result.found;
         let tt_data = tt_result.data;
         // rootNode では ttMove = rootMoves[0]
@@ -1923,7 +1924,8 @@ impl SearchWorker {
 
         // rootでもTT probeを行い、ttHit/ttPvを更新
         let key = pos.key();
-        let tt_result = self.tt.probe(key, pos);
+        let tt = Arc::clone(&self.tt);
+        let tt_result = tt.probe(key, pos);
         let tt_hit = tt_result.found;
         let tt_data = tt_result.data;
         // rootNode && pvIdx 経路では rootMoves[pv_idx] を ttMove 相当として扱う。

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1819,7 +1819,8 @@ impl SearchWorker {
             } else {
                 (depth + 6).min(MAX_PLY - 1)
             };
-            tt_ctx_root.result.write(
+            // root 保存は統計・トレースを伴わないため、競合による skip をそのまま許容する。
+            let _ = tt_ctx_root.result.write(
                 key,
                 value_to_tt(best_value, 0),
                 true, // PvNode

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -3943,7 +3943,18 @@ impl SearchWorker {
                 && helper_tt_write_enabled_for_depth(ctx.thread_id, bound, stored_depth);
             #[cfg(not(feature = "tt-trace"))]
             let allow_write = ctx.allow_tt_write;
-            if allow_write {
+            if allow_write
+                && tt_ctx.result.write(
+                    tt_ctx.key,
+                    value_to_tt(best_value, ply),
+                    st.stack[ply as usize].tt_pv,
+                    bound,
+                    stored_depth,
+                    best_move,
+                    eval_ctx.unadjusted_static_eval,
+                    ctx.tt.generation(),
+                )
+            {
                 #[cfg(feature = "tt-trace")]
                 maybe_trace_tt_write(TtWriteTrace {
                     stage: "ab_store",
@@ -3962,16 +3973,6 @@ impl SearchWorker {
                         Move::NONE
                     },
                 });
-                tt_ctx.result.write(
-                    tt_ctx.key,
-                    value_to_tt(best_value, ply),
-                    st.stack[ply as usize].tt_pv,
-                    bound,
-                    stored_depth,
-                    best_move,
-                    eval_ctx.unadjusted_static_eval,
-                    ctx.tt.generation(),
-                );
                 inc_stat_by_depth!(st, tt_write_by_depth, stored_depth);
             }
         }

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1819,7 +1819,7 @@ impl SearchWorker {
             } else {
                 (depth + 6).min(MAX_PLY - 1)
             };
-            // root 保存は統計・トレースを伴わないため、競合による skip をそのまま許容する。
+            // root 保存は統計・トレースを伴わないため、格納可否を見ない。
             let _ = tt_ctx_root.result.write(
                 key,
                 value_to_tt(best_value, 0),

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -363,7 +363,18 @@ pub(super) fn probe_transposition<'a, const NT: u8>(
                 && helper_tt_write_enabled_for_depth(ctx.thread_id, Bound::Exact, stored_depth);
             #[cfg(not(feature = "tt-trace"))]
             let allow_write = ctx.allow_tt_write;
-            if allow_write {
+            if allow_write
+                && tt_result.write(
+                    key,
+                    value,
+                    st.stack[ply as usize].tt_pv,
+                    Bound::Exact,
+                    stored_depth,
+                    mate_move,
+                    Value::NONE,
+                    ctx.tt.generation(),
+                )
+            {
                 #[cfg(feature = "tt-trace")]
                 maybe_trace_tt_write(TtWriteTrace {
                     stage: "ab_mate1_store",
@@ -382,16 +393,6 @@ pub(super) fn probe_transposition<'a, const NT: u8>(
                         Move::NONE
                     },
                 });
-                tt_result.write(
-                    key,
-                    value,
-                    st.stack[ply as usize].tt_pv,
-                    Bound::Exact,
-                    stored_depth,
-                    mate_move,
-                    Value::NONE,
-                    ctx.tt.generation(),
-                );
                 inc_stat_by_depth!(st, tt_write_by_depth, stored_depth);
             }
             // 1手詰めカットオフではヒストリ更新不要（mate_moveは特殊）
@@ -518,7 +519,18 @@ pub(super) fn compute_eval_context(
         && helper_tt_write_enabled_for_depth(ctx.thread_id, Bound::None, DEPTH_UNSEARCHED);
     #[cfg(not(feature = "tt-trace"))]
     let eval_allow_write = !in_check && !tt_ctx.hit && ctx.allow_tt_write;
-    if eval_allow_write {
+    if eval_allow_write
+        && tt_ctx.result.write(
+            tt_ctx.key,
+            Value::NONE,
+            st.stack[ply as usize].tt_pv,
+            Bound::None,
+            DEPTH_UNSEARCHED,
+            Move::NONE,
+            unadjusted_static_eval,
+            ctx.tt.generation(),
+        )
+    {
         #[cfg(feature = "tt-trace")]
         maybe_trace_tt_write(TtWriteTrace {
             stage: "ab_eval_store_none",
@@ -537,16 +549,6 @@ pub(super) fn compute_eval_context(
                 Move::NONE
             },
         });
-        tt_ctx.result.write(
-            tt_ctx.key,
-            Value::NONE,
-            st.stack[ply as usize].tt_pv,
-            Bound::None,
-            DEPTH_UNSEARCHED,
-            Move::NONE,
-            unadjusted_static_eval,
-            ctx.tt.generation(),
-        );
         inc_stat_by_depth!(st, tt_write_by_depth, 0);
     }
 

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -199,9 +199,9 @@ pub(super) fn update_correction_history(
 
 /// 置換表プローブ
 #[allow(clippy::too_many_arguments)]
-pub(super) fn probe_transposition<const NT: u8>(
+pub(super) fn probe_transposition<'a, const NT: u8>(
     st: &mut SearchState,
-    ctx: &SearchContext<'_>,
+    ctx: &SearchContext<'a>,
     pos: &mut Position,
     depth: Depth,
     beta: Value,
@@ -210,7 +210,7 @@ pub(super) fn probe_transposition<const NT: u8>(
     in_check: bool,
     excluded_move: Move,
     cut_node: bool,
-) -> ProbeOutcome {
+) -> ProbeOutcome<'a> {
     let key = pos.key();
 
     let tt_result = ctx.tt.probe(key, pos);

--- a/crates/rshogi-core/src/search/pruning.rs
+++ b/crates/rshogi-core/src/search/pruning.rs
@@ -573,7 +573,18 @@ where
                 && helper_tt_write_enabled_for_depth(ctx.thread_id, Bound::Lower, stored_depth);
             #[cfg(not(feature = "tt-trace"))]
             let allow_write = ctx.allow_tt_write;
-            if allow_write {
+            if allow_write
+                && tt_ctx.result.write(
+                    tt_ctx.key,
+                    value_to_tt(value, ply),
+                    st.stack[ply as usize].tt_pv,
+                    Bound::Lower,
+                    stored_depth,
+                    mv,
+                    unadjusted_static_eval,
+                    ctx.tt.generation(),
+                )
+            {
                 #[cfg(feature = "tt-trace")]
                 maybe_trace_tt_write(TtWriteTrace {
                     stage: "probcut_store",
@@ -592,16 +603,6 @@ where
                         Move::NONE
                     },
                 });
-                tt_ctx.result.write(
-                    tt_ctx.key,
-                    value_to_tt(value, ply),
-                    st.stack[ply as usize].tt_pv,
-                    Bound::Lower,
-                    stored_depth,
-                    mv,
-                    unadjusted_static_eval,
-                    ctx.tt.generation(),
-                );
                 inc_stat_by_depth!(st, tt_write_by_depth, stored_depth);
             }
 

--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -208,7 +208,19 @@ pub(super) fn qsearch<const NT: u8>(
                     && helper_tt_write_enabled_for_depth(ctx.thread_id, Bound::Exact, DEPTH_QS);
                 #[cfg(not(feature = "tt-trace"))]
                 let allow_write = ctx.allow_tt_write;
-                if allow_write {
+                if allow_write
+                    && tt_result.write(
+                        key,
+                        mate_value,
+                        // SAFETY: ply < MAX_PLY < STACK_SIZEを満たす探索局面のttPvを使う。
+                        unsafe { st.stack.get_unchecked(ply as usize) }.tt_pv,
+                        Bound::Exact,
+                        DEPTH_QS,
+                        mate_move,
+                        unadjusted_static_eval,
+                        ctx.tt.generation(),
+                    )
+                {
                     #[cfg(feature = "tt-trace")]
                     maybe_trace_tt_write(TtWriteTrace {
                         stage: "qsearch_mate1_store",
@@ -229,17 +241,6 @@ pub(super) fn qsearch<const NT: u8>(
                             Move::NONE
                         },
                     });
-                    // mate1ではss->ttPvを使用
-                    tt_result.write(
-                        key,
-                        mate_value,
-                        unsafe { st.stack.get_unchecked(ply as usize) }.tt_pv,
-                        Bound::Exact,
-                        DEPTH_QS,
-                        mate_move,
-                        unadjusted_static_eval,
-                        ctx.tt.generation(),
-                    );
                     inc_stat_by_depth!(st, tt_write_by_depth, 0);
                 }
                 return mate_value;
@@ -295,7 +296,18 @@ pub(super) fn qsearch<const NT: u8>(
                 && helper_tt_write_enabled_for_depth(ctx.thread_id, Bound::Lower, DEPTH_UNSEARCHED);
             #[cfg(not(feature = "tt-trace"))]
             let allow_write = ctx.allow_tt_write;
-            if allow_write {
+            if allow_write
+                && tt_result.write(
+                    key,
+                    value_to_tt(v, ply),
+                    false,
+                    Bound::Lower,
+                    DEPTH_UNSEARCHED,
+                    Move::NONE,
+                    unadjusted_static_eval,
+                    ctx.tt.generation(),
+                )
+            {
                 #[cfg(feature = "tt-trace")]
                 maybe_trace_tt_write(TtWriteTrace {
                     stage: "qsearch_stand_pat_store",
@@ -314,16 +326,6 @@ pub(super) fn qsearch<const NT: u8>(
                         Move::NONE
                     },
                 });
-                tt_result.write(
-                    key,
-                    value_to_tt(v, ply),
-                    false,
-                    Bound::Lower,
-                    DEPTH_UNSEARCHED,
-                    Move::NONE,
-                    unadjusted_static_eval,
-                    ctx.tt.generation(),
-                );
                 inc_stat_by_depth!(st, tt_write_by_depth, 0);
             }
         }
@@ -521,7 +523,18 @@ pub(super) fn qsearch<const NT: u8>(
         ctx.allow_tt_write && helper_tt_write_enabled_for_depth(ctx.thread_id, bound, DEPTH_QS);
     #[cfg(not(feature = "tt-trace"))]
     let allow_write = ctx.allow_tt_write;
-    if allow_write {
+    if allow_write
+        && tt_result.write(
+            key,
+            value_to_tt(best_value, ply),
+            pv_hit,
+            bound,
+            DEPTH_QS,
+            best_move,
+            unadjusted_static_eval,
+            ctx.tt.generation(),
+        )
+    {
         #[cfg(feature = "tt-trace")]
         maybe_trace_tt_write(TtWriteTrace {
             stage: "qsearch_store",
@@ -540,16 +553,6 @@ pub(super) fn qsearch<const NT: u8>(
                 Move::NONE
             },
         });
-        tt_result.write(
-            key,
-            value_to_tt(best_value, ply),
-            pv_hit,
-            bound,
-            DEPTH_QS,
-            best_move,
-            unadjusted_static_eval,
-            ctx.tt.generation(),
-        );
         inc_stat_by_depth!(st, tt_write_by_depth, 0);
     }
 

--- a/crates/rshogi-core/src/tt/alloc.rs
+++ b/crates/rshogi-core/src/tt/alloc.rs
@@ -222,6 +222,5 @@ impl Drop for Allocation {
     }
 }
 
-// SAFETY: Allocation owns raw memory for the TT and is protected by higher-level synchronization.
+// SAFETY: 割当を単独所有し、所有権の移動後も同じレイアウトで解放する。共有の安全性は格納型側で保証する。
 unsafe impl Send for Allocation {}
-unsafe impl Sync for Allocation {}

--- a/crates/rshogi-core/src/tt/entry.rs
+++ b/crates/rshogi-core/src/tt/entry.rs
@@ -7,7 +7,8 @@
 //! YaneuraOu（CLUSTER_SIZE=3）準拠で16bitキーを使用。
 //! クラスターインデックスは64bitキーの上位ビットで決定し、
 //! クラスター内マッチングに下位16bitを使用する。
-//! 衝突確率は 3/65536 ≈ 0.005% と十分低く、Move合法性検証が二重チェックとして機能する。
+//! 独立一様な短縮キーの偶然一致は最大3/65536程度。並行更新による混在の確率とは異なる。
+//! 手の検証は不正な着手を防ぐが、短縮キーと探索値の対応は保証しない。
 
 use super::{GENERATION_CYCLE, GENERATION_MASK};
 use crate::types::{Bound, DEPTH_ENTRY_OFFSET, Move, Value};
@@ -45,6 +46,28 @@ impl TTEntry {
             move16: 0,
             value16: 0,
             eval16: 0,
+        }
+    }
+
+    // payloadを単一wordにまとめ、探索値とbound/depthを同時に読み書きする。
+    #[inline]
+    pub(super) fn payload(self) -> u64 {
+        self.depth8 as u64
+            | ((self.gen_bound8 as u64) << 8)
+            | ((self.move16 as u64) << 16)
+            | ((self.value16 as u16 as u64) << 32)
+            | ((self.eval16 as u16 as u64) << 48)
+    }
+
+    #[inline]
+    pub(super) fn from_payload(key16: u16, payload: u64) -> Self {
+        Self {
+            key16,
+            depth8: payload as u8,
+            gen_bound8: (payload >> 8) as u8,
+            move16: (payload >> 16) as u16,
+            value16: (payload >> 32) as i16,
+            eval16: (payload >> 48) as i16,
         }
     }
 
@@ -142,49 +165,6 @@ impl TTEntry {
     }
 }
 
-/// 共有テーブル上の格納形式。複数フィールドの整合性は Cluster のガードが保証する。
-#[repr(C)]
-pub(super) struct AtomicTTEntry {
-    words: [std::sync::atomic::AtomicU16; 5],
-}
-
-impl AtomicTTEntry {
-    pub(super) const fn new() -> Self {
-        Self {
-            words: [const { std::sync::atomic::AtomicU16::new(0) }; 5],
-        }
-    }
-
-    pub(super) fn load(&self) -> TTEntry {
-        use std::sync::atomic::Ordering;
-        let words = self.words.each_ref().map(|word| word.load(Ordering::Relaxed));
-        TTEntry {
-            key16: words[0],
-            depth8: words[1] as u8,
-            gen_bound8: (words[1] >> 8) as u8,
-            move16: words[2],
-            value16: words[3] as i16,
-            eval16: words[4] as i16,
-        }
-    }
-
-    pub(super) fn store(&self, entry: TTEntry) {
-        use std::sync::atomic::Ordering;
-        let words = [
-            entry.key16,
-            entry.depth8 as u16 | ((entry.gen_bound8 as u16) << 8),
-            entry.move16,
-            entry.value16 as u16,
-            entry.eval16 as u16,
-        ];
-        for (word, value) in self.words.iter().zip(words) {
-            word.store(value, Ordering::Relaxed);
-        }
-    }
-}
-
-const _: () = assert!(std::mem::size_of::<AtomicTTEntry>() == 10);
-
 /// 置換表から読み取ったデータ
 #[derive(Clone, Copy, Debug)]
 pub struct TTData {
@@ -224,6 +204,31 @@ impl Default for TTData {
 mod tests {
     use super::*;
     use crate::types::{File, Rank, Square};
+
+    #[test]
+    fn test_payload_roundtrip() {
+        for depth8 in [0, 1, 127, 255] {
+            for gen_bound8 in 0..=255 {
+                for bits in [0, 1, 0x7fff, 0x8000, 0xffff] {
+                    let entry = TTEntry {
+                        key16: 0xabcd,
+                        depth8,
+                        gen_bound8,
+                        move16: bits,
+                        value16: bits as i16,
+                        eval16: !bits as i16,
+                    };
+                    let decoded = TTEntry::from_payload(entry.key16(), entry.payload());
+                    assert_eq!(decoded.key16, entry.key16);
+                    assert_eq!(decoded.depth8, entry.depth8);
+                    assert_eq!(decoded.gen_bound8, entry.gen_bound8);
+                    assert_eq!(decoded.move16, entry.move16);
+                    assert_eq!(decoded.value16, entry.value16);
+                    assert_eq!(decoded.eval16, entry.eval16);
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_tt_entry_new() {

--- a/crates/rshogi-core/src/tt/entry.rs
+++ b/crates/rshogi-core/src/tt/entry.rs
@@ -142,6 +142,49 @@ impl TTEntry {
     }
 }
 
+/// 共有テーブル上の格納形式。複数フィールドの整合性は Cluster のガードが保証する。
+#[repr(C)]
+pub(super) struct AtomicTTEntry {
+    words: [std::sync::atomic::AtomicU16; 5],
+}
+
+impl AtomicTTEntry {
+    pub(super) const fn new() -> Self {
+        Self {
+            words: [const { std::sync::atomic::AtomicU16::new(0) }; 5],
+        }
+    }
+
+    pub(super) fn load(&self) -> TTEntry {
+        use std::sync::atomic::Ordering;
+        let words = self.words.each_ref().map(|word| word.load(Ordering::Relaxed));
+        TTEntry {
+            key16: words[0],
+            depth8: words[1] as u8,
+            gen_bound8: (words[1] >> 8) as u8,
+            move16: words[2],
+            value16: words[3] as i16,
+            eval16: words[4] as i16,
+        }
+    }
+
+    pub(super) fn store(&self, entry: TTEntry) {
+        use std::sync::atomic::Ordering;
+        let words = [
+            entry.key16,
+            entry.depth8 as u16 | ((entry.gen_bound8 as u16) << 8),
+            entry.move16,
+            entry.value16 as u16,
+            entry.eval16 as u16,
+        ];
+        for (word, value) in self.words.iter().zip(words) {
+            word.store(value, Ordering::Relaxed);
+        }
+    }
+}
+
+const _: () = assert!(std::mem::size_of::<AtomicTTEntry>() == 10);
+
 /// 置換表から読み取ったデータ
 #[derive(Clone, Copy, Debug)]
 pub struct TTData {

--- a/crates/rshogi-core/src/tt/mod.rs
+++ b/crates/rshogi-core/src/tt/mod.rs
@@ -12,8 +12,9 @@
 //!
 //! クラスターインデックスは64bitキーの上位ビットで決定し、
 //! クラスター内マッチングに下位16bitを使用する。
-//! 10バイトatomic格納 × 3 + 1バイト排他 + 1パディング = 32バイト/クラスター。
-//! 読み書きはクラスタ単位の短い排他でsnapshotの整合性を保証し、競合時は待たずにmiss/書込み省略とする。
+//! payload の AtomicU64 × 3 + 短縮キーの AtomicU16 × 3 + 2バイトパディング
+//! = 32バイト/クラスター。排他は取らず、payload 内のフィールド対応だけを不可分に保つ。
+//! 短縮キーと payload は別ワードなので、異なる書込みの組が観測されうる。
 
 mod alloc;
 mod entry;
@@ -23,7 +24,7 @@ pub use entry::{TTData, TTEntry};
 pub use table::{ProbeResult, TranspositionTable};
 
 /// クラスターサイズ（エントリ数）
-/// YaneuraOu準拠: 10bytes × 3 + lock/padding 2bytes = 32bytes
+/// YaneuraOu準拠: payload 8bytes × 3 + 短縮キー 2bytes × 3 + padding 2bytes = 32bytes
 pub const CLUSTER_SIZE: usize = 3;
 
 /// Generation関連の定数

--- a/crates/rshogi-core/src/tt/mod.rs
+++ b/crates/rshogi-core/src/tt/mod.rs
@@ -12,7 +12,8 @@
 //!
 //! クラスターインデックスは64bitキーの上位ビットで決定し、
 //! クラスター内マッチングに下位16bitを使用する。
-//! 10バイトエントリ × 3 + 2パディング = 32バイト/クラスター。
+//! 10バイトatomic格納 × 3 + 1バイト排他 + 1パディング = 32バイト/クラスター。
+//! 読み書きはクラスタ単位の短い排他でsnapshotの整合性を保証し、競合時は待たずにmiss/書込み省略とする。
 
 mod alloc;
 mod entry;
@@ -22,7 +23,7 @@ pub use entry::{TTData, TTEntry};
 pub use table::{ProbeResult, TranspositionTable};
 
 /// クラスターサイズ（エントリ数）
-/// YaneuraOu準拠: 10bytes × 3 + 2padding = 32bytes
+/// YaneuraOu準拠: 10bytes × 3 + lock/padding 2bytes = 32bytes
 pub const CLUSTER_SIZE: usize = 3;
 
 /// Generation関連の定数

--- a/crates/rshogi-core/src/tt/table.rs
+++ b/crates/rshogi-core/src/tt/table.rs
@@ -5,62 +5,49 @@
 //! - probe/write操作
 
 use super::alloc::{AllocKind, Allocation};
-use super::entry::{AtomicTTEntry, TTData, TTEntry};
+use super::entry::{TTData, TTEntry};
 use super::{CLUSTER_SIZE, GENERATION_DELTA};
 use crate::position::Position;
 use crate::prefetch::TtPrefetch;
 use crate::types::{Bound, Color, Move, Value};
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU16, AtomicU64, Ordering};
 
-/// 3 エントリと排他フラグを同じ32バイトに格納する。
+/// 3 エントリを32バイトに格納し、payloadと短縮キーを別々のatomicで共有する。
 #[repr(C, align(32))]
 pub struct Cluster {
-    entries: [AtomicTTEntry; CLUSTER_SIZE],
-    locked: AtomicBool,
-    padding: u8,
+    data: [AtomicU64; CLUSTER_SIZE],
+    keys: [AtomicU16; CLUSTER_SIZE],
+    padding: [u8; 2],
 }
 
 impl Cluster {
     const fn new() -> Self {
         Self {
-            entries: [const { AtomicTTEntry::new() }; CLUSTER_SIZE],
-            locked: AtomicBool::new(false),
-            padding: 0,
+            data: [const { AtomicU64::new(0) }; CLUSTER_SIZE],
+            keys: [const { AtomicU16::new(0) }; CLUSTER_SIZE],
+            padding: [0; 2],
         }
     }
 
-    /// TT は読み捨て可能なキャッシュなので、競合時は待機せず利用を見送る。
-    fn try_lock(&self) -> Option<ClusterGuard<'_>> {
-        self.locked
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .ok()
-            .map(|_| ClusterGuard { cluster: self })
+    #[inline]
+    fn load(&self, index: usize) -> TTEntry {
+        let key = self.keys[index].load(Ordering::Relaxed);
+        let payload = self.data[index].load(Ordering::Relaxed);
+        TTEntry::from_payload(key, payload)
+    }
+
+    #[inline]
+    fn store(&self, index: usize, entry: TTEntry) {
+        // keyとpayloadの同時公開は保証しない。payload内の対応だけを不可分に保つ。
+        self.keys[index].store(entry.key16(), Ordering::Relaxed);
+        self.data[index].store(entry.payload(), Ordering::Relaxed);
     }
 }
 
 impl Default for Cluster {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-struct ClusterGuard<'a> {
-    cluster: &'a Cluster,
-}
-
-impl ClusterGuard<'_> {
-    fn load(&self, index: usize) -> TTEntry {
-        self.cluster.entries[index].load()
-    }
-    fn store(&self, index: usize, entry: TTEntry) {
-        self.cluster.entries[index].store(entry);
-    }
-}
-
-impl Drop for ClusterGuard<'_> {
-    fn drop(&mut self) {
-        self.cluster.locked.store(false, Ordering::Release);
     }
 }
 
@@ -71,7 +58,7 @@ struct ClusterTable {
     len: usize,
 }
 
-// SAFETY: 共有参照から触れる格納要素はすべてatomicで、snapshotはClusterGuardで排他する。
+// SAFETY: 共有参照から更新する格納要素はすべてatomicで、読み取りは所有値に復号する。
 // 割当の解放・resize・clearは &mut self を要求し、借用中のprobe writerとは共存しない。
 unsafe impl Sync for ClusterTable {}
 
@@ -81,7 +68,7 @@ impl ClusterTable {
         let alloc = Allocation::allocate(bytes, std::mem::align_of::<Cluster>());
         let ptr = alloc.ptr().as_ptr() as *mut Cluster;
         // SAFETY: Clusterのアラインメントとlen個分の領域を確保済み。全フィールドはゼロが有効で、
-        // AtomicBoolはfalse、AtomicU16は0となる。初期化中の割当はまだ共有されていない。
+        // AtomicU64/AtomicU16とpaddingは0となる。初期化中の割当はまだ共有されていない。
         unsafe {
             std::ptr::write_bytes(ptr, 0, len);
         }
@@ -181,22 +168,15 @@ impl TranspositionTable {
     }
 
     /// 置換表を検索（クラスター内は16bitキーでマッチング）。
-    /// 他スレッドが同じクラスターを操作中ならmissを返し、このprobeからの書込みも省略する。
+    /// keyとpayloadの一貫性は保証せず、短縮キーと手の整合性で候補を検査する。
     pub fn probe(&self, key: u64, pos: &Position) -> ProbeResult<'_> {
         let cluster = self.first_entry(key, pos.side_to_move());
-        let Some(guard) = cluster.try_lock() else {
-            return ProbeResult {
-                found: false,
-                data: TTData::EMPTY,
-                writer: None,
-            };
-        };
         let key16 = key as u16;
         let gen8 = self.generation();
         let mut replace = 0;
         let mut min_value = i32::MAX;
         for index in 0..CLUSTER_SIZE {
-            let entry = guard.load(index);
+            let entry = cluster.load(index);
             if entry.key16() == key16 {
                 let mut data = entry.read();
                 if data.mv != Move::NONE {
@@ -215,7 +195,7 @@ impl TranspositionTable {
                 return ProbeResult {
                     found: entry.is_occupied(),
                     data,
-                    writer: Some((cluster, index)),
+                    writer: (cluster, index),
                 };
             }
             let value = entry.depth8() as i32 - entry.relative_age(gen8) as i32;
@@ -227,7 +207,7 @@ impl TranspositionTable {
         ProbeResult {
             found: false,
             data: TTData::EMPTY,
-            writer: Some((cluster, replace)),
+            writer: (cluster, replace),
         }
     }
 
@@ -239,11 +219,8 @@ impl TranspositionTable {
         let sample_count = 1000.min(self.cluster_count);
 
         for cluster in self.table.iter().take(sample_count) {
-            let Some(guard) = cluster.try_lock() else {
-                continue;
-            };
             for index in 0..CLUSTER_SIZE {
-                let entry = guard.load(index);
+                let entry = cluster.load(index);
                 if entry.is_occupied() && entry.relative_age(gen8) <= max_age_internal {
                     count += 1;
                 }
@@ -328,15 +305,15 @@ pub struct ProbeResult<'a> {
     /// 読み取ったデータ
     pub data: TTData,
     /// 書き込み用エントリ
-    writer: Option<(&'a Cluster, usize)>,
+    writer: (&'a Cluster, usize),
 }
 
 impl ProbeResult<'_> {
     /// エントリに書き込む（内部で16bitに切り詰め）
     ///
-    /// probe後の別writerによる更新を再読込し、排他下で置換条件を判定する。
-    /// probe時または書込み時の競合で見送った場合はfalse、置換条件を適用して格納した場合はtrueを返す。
-    /// trueでも置換条件により既存の値が保持されることがある。
+    /// probe後のslotを再読込し、置換条件を適用して格納する。競合による省略はなく常にtrue。
+    /// trueは格納操作の完了を表し、値の変更や並行writerによる上書きがないことは保証しない。
+    /// 統計・トレースの成功判定契約を保つため、戻り値を維持する。
     ///
     /// 戻り値を捨てる呼び出しは、格納の成否に依存する記録 (統計・トレース) を
     /// 伴わないことを `let _ =` で明示する。
@@ -352,15 +329,10 @@ impl ProbeResult<'_> {
         eval: Value,
         generation8: u8,
     ) -> bool {
-        let Some((cluster, index)) = self.writer else {
-            return false;
-        };
-        let Some(guard) = cluster.try_lock() else {
-            return false;
-        };
-        let mut entry = guard.load(index);
+        let (cluster, index) = self.writer;
+        let mut entry = cluster.load(index);
         entry.save(key, value, is_pv, bound, depth, mv, eval, generation8);
-        guard.store(index, entry);
+        cluster.store(index, entry);
         true
     }
 }
@@ -376,6 +348,71 @@ impl TtPrefetch for TranspositionTable {
 mod tests {
     use super::*;
     use crate::position::{Position, SFEN_HIRATE};
+
+    #[test]
+    fn test_key_can_mix_with_complete_payload() {
+        let tt = TranspositionTable::new(0);
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let cluster = tt.first_entry(1, pos.side_to_move());
+        let mut entry = TTEntry::new();
+        entry.save(2, Value::new(900), true, Bound::Lower, 20, Move::NONE, Value::new(-50), 8);
+        cluster.store(0, entry);
+        // 別writerのkeyだけが見える状態でも、key照合はpayloadの出所を検証できない。
+        cluster.keys[0].store(1, Ordering::Relaxed);
+        let probe = tt.probe(1, &pos);
+        assert!(probe.found);
+        assert_eq!(probe.data.value.raw(), 900);
+        assert_eq!(probe.data.eval.raw(), -50);
+        assert_eq!(probe.data.depth, 20);
+        assert_eq!(probe.data.bound, Bound::Lower);
+        assert!(probe.data.is_pv);
+        assert!(probe.data.bound.can_cutoff(probe.data.value, Value::new(100)));
+    }
+
+    #[test]
+    fn test_probe_key_and_move_validation_limits() {
+        use super::super::entry::TTEntry;
+        let tt = TranspositionTable::new(0);
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let cluster = tt.first_entry(1, pos.side_to_move());
+        let mut entry = TTEntry::new();
+        entry.save(2, Value::new(900), false, Bound::Lower, 10, Move::NONE, Value::ZERO, 0);
+        cluster.store(0, entry);
+        assert!(!tt.probe(1, &pos).found);
+
+        // 移動元が空なら、短縮キーが一致しても採用しない。
+        entry.save(
+            1,
+            Value::new(900),
+            false,
+            Bound::Lower,
+            10,
+            Move::from_usi("7f7e").unwrap(),
+            Value::ZERO,
+            0,
+        );
+        cluster.store(0, entry);
+        assert!(!tt.probe(1, &pos).found);
+
+        // 駒の移動規則はprobeでは検証せず、探索側の疑似合法検査で除外する。
+        entry.save(
+            1,
+            Value::new(900),
+            false,
+            Bound::Lower,
+            10,
+            Move::from_usi("7g7e").unwrap(),
+            Value::ZERO,
+            0,
+        );
+        cluster.store(0, entry);
+        let probe = tt.probe(1, &pos);
+        assert!(probe.found);
+        assert!(!pos.pseudo_legal(probe.data.mv));
+        assert!(probe.data.bound.can_cutoff(probe.data.value, Value::new(100)));
+    }
 
     #[test]
     fn test_stale_writer_rechecks_latest_entry() {
@@ -433,88 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cluster_contention_skips_probe_and_write() {
-        let tt = TranspositionTable::new(0);
-        let pos = Position::new();
-        let writer = tt.probe(1, &pos);
-        let cluster = tt.first_entry(1, pos.side_to_move());
-        let guard = cluster.try_lock().unwrap();
-        let skipped_probe = tt.probe(1, &pos);
-        assert!(!skipped_probe.found);
-        assert!(!writer.write(
-            1,
-            Value::new(99),
-            false,
-            Bound::Exact,
-            10,
-            Move::NONE,
-            Value::ZERO,
-            0
-        ));
-        assert!(!guard.load(0).is_occupied());
-        drop(guard);
-        assert!(!skipped_probe.write(
-            1,
-            Value::new(99),
-            false,
-            Bound::Exact,
-            10,
-            Move::NONE,
-            Value::ZERO,
-            0
-        ));
-        assert!(!tt.probe(1, &pos).found);
-        assert!(writer.write(
-            1,
-            Value::new(99),
-            false,
-            Bound::Exact,
-            10,
-            Move::NONE,
-            Value::ZERO,
-            0
-        ));
-        assert_eq!(tt.probe(1, &pos).data.value.raw(), 99);
-    }
-
-    #[test]
-    fn test_probe_contention_writer_stays_skipped_after_unlock() {
-        let tt = TranspositionTable::new(0);
-        let pos = Position::new();
-        assert!(tt.probe(1, &pos).write(
-            1,
-            Value::new(99),
-            false,
-            Bound::Exact,
-            10,
-            Move::NONE,
-            Value::ZERO,
-            0,
-        ));
-        let cluster = tt.first_entry(1, pos.side_to_move());
-        let guard = cluster.try_lock().unwrap();
-        let skipped_probe = tt.probe(1, &pos);
-        assert!(!skipped_probe.found);
-        drop(guard);
-
-        assert!(!skipped_probe.write(
-            1,
-            Value::new(42),
-            false,
-            Bound::Exact,
-            20,
-            Move::NONE,
-            Value::ZERO,
-            0,
-        ));
-        let preserved = tt.probe(1, &pos);
-        assert!(preserved.found);
-        assert_eq!(preserved.data.value.raw(), 99);
-        assert_eq!(preserved.data.depth, 10);
-    }
-
-    #[test]
-    fn test_competing_writers_publish_consistent_entries() {
+    fn test_competing_writers_share_slot_without_skipping() {
         use std::sync::{Arc, Barrier};
         let tt = TranspositionTable::new(0);
         let mut pos = Position::new();
@@ -527,10 +483,10 @@ mod tests {
                 let pos = &pos;
                 scope.spawn(move || {
                     let mv = Move::from_usi(if key == 1 { "7g7f" } else { "2g2f" }).unwrap();
+                    let writer = tt.probe(key, pos);
                     barrier.wait();
                     for _ in 0..10_000 {
-                        // 競合時の skip 自体が検証対象なので、ここでは成否を問わない。
-                        let _ = tt.probe(key, pos).write(
+                        assert!(writer.write(
                             key,
                             Value::new(key as i32 * 100),
                             key == 1,
@@ -539,7 +495,7 @@ mod tests {
                             mv,
                             Value::new(-(key as i32)),
                             0,
-                        );
+                        ));
                     }
                 });
             }
@@ -553,14 +509,18 @@ mod tests {
                         for key in [1, 2] {
                             let probe = tt.probe(key, pos);
                             if probe.found {
-                                assert_eq!(probe.data.value.raw(), key as i32 * 100);
-                                assert_eq!(probe.data.eval.raw(), -(key as i32));
-                                assert_eq!(probe.data.depth, key as i32 * 10);
-                                assert_eq!(probe.data.is_pv, key == 1);
-                                assert_eq!(probe.data.bound, Bound::Exact);
+                                // keyとの対応は保証しないが、payload内は同じ書込みに由来する。
+                                let data = probe.data;
+                                let source = data.value.raw() / 100;
+                                assert!([1, 2].contains(&source));
+                                assert_eq!(data.value.raw(), source * 100);
+                                assert_eq!(data.eval.raw(), -source);
+                                assert_eq!(data.depth, source * 10);
+                                assert_eq!(data.bound, Bound::Exact);
+                                assert_eq!(data.is_pv, source == 1);
                                 assert_eq!(
-                                    probe.data.mv.to_usi(),
-                                    if key == 1 { "7g7f" } else { "2g2f" }
+                                    data.mv.to_usi(),
+                                    if source == 1 { "7g7f" } else { "2g2f" }
                                 );
                             }
                         }

--- a/crates/rshogi-core/src/tt/table.rs
+++ b/crates/rshogi-core/src/tt/table.rs
@@ -5,30 +5,37 @@
 //! - probe/write操作
 
 use super::alloc::{AllocKind, Allocation};
-use super::entry::{TTData, TTEntry};
+use super::entry::{AtomicTTEntry, TTData, TTEntry};
 use super::{CLUSTER_SIZE, GENERATION_DELTA};
 use crate::position::Position;
 use crate::prefetch::TtPrefetch;
 use crate::types::{Bound, Color, Move, Value};
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
-/// クラスター構造
-/// 同じハッシュインデックスに対して複数のエントリを持つ
-/// YaneuraOu（CLUSTER_SIZE=3）準拠: 10bytes × 3 + 2padding = 32bytes
+/// 3 エントリと排他フラグを同じ32バイトに格納する。
 #[repr(C, align(32))]
 pub struct Cluster {
-    entries: [TTEntry; CLUSTER_SIZE],
-    _padding: [u8; 2], // 10 * 3 + 2 = 32 bytes
+    entries: [AtomicTTEntry; CLUSTER_SIZE],
+    locked: AtomicBool,
+    padding: u8,
 }
 
 impl Cluster {
-    /// 新しいクラスターを作成
     const fn new() -> Self {
         Self {
-            entries: [TTEntry::new(); CLUSTER_SIZE],
-            _padding: [0; 2],
+            entries: [const { AtomicTTEntry::new() }; CLUSTER_SIZE],
+            locked: AtomicBool::new(false),
+            padding: 0,
         }
+    }
+
+    /// TT は読み捨て可能なキャッシュなので、競合時は待機せず利用を見送る。
+    fn try_lock(&self) -> Option<ClusterGuard<'_>> {
+        self.locked
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .ok()
+            .map(|_| ClusterGuard { cluster: self })
     }
 }
 
@@ -38,16 +45,25 @@ impl Default for Cluster {
     }
 }
 
-impl Clone for Cluster {
-    fn clone(&self) -> Self {
-        Self {
-            entries: self.entries,
-            _padding: self._padding,
-        }
+struct ClusterGuard<'a> {
+    cluster: &'a Cluster,
+}
+
+impl ClusterGuard<'_> {
+    fn load(&self, index: usize) -> TTEntry {
+        self.cluster.entries[index].load()
+    }
+    fn store(&self, index: usize, entry: TTEntry) {
+        self.cluster.entries[index].store(entry);
     }
 }
 
-// クラスターは32バイトであることを保証（YaneuraOu CLUSTER_SIZE=3 準拠）
+impl Drop for ClusterGuard<'_> {
+    fn drop(&mut self) {
+        self.cluster.locked.store(false, Ordering::Release);
+    }
+}
+
 const _: () = assert!(std::mem::size_of::<Cluster>() == 32);
 
 struct ClusterTable {
@@ -55,11 +71,17 @@ struct ClusterTable {
     len: usize,
 }
 
+// SAFETY: 共有参照から触れる格納要素はすべてatomicで、snapshotはClusterGuardで排他する。
+// 割当の解放・resize・clearは &mut self を要求し、借用中のprobe writerとは共存しない。
+unsafe impl Sync for ClusterTable {}
+
 impl ClusterTable {
     fn new(len: usize) -> Self {
         let bytes = len * std::mem::size_of::<Cluster>();
         let alloc = Allocation::allocate(bytes, std::mem::align_of::<Cluster>());
         let ptr = alloc.ptr().as_ptr() as *mut Cluster;
+        // SAFETY: Clusterのアラインメントとlen個分の領域を確保済み。全フィールドはゼロが有効で、
+        // AtomicBoolはfalse、AtomicU16は0となる。初期化中の割当はまだ共有されていない。
         unsafe {
             std::ptr::write_bytes(ptr, 0, len);
         }
@@ -75,12 +97,14 @@ impl Deref for ClusterTable {
     type Target = [Cluster];
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: allocはlen個の初期化済みClusterを所有し、この借用中は解放されない。
         unsafe { std::slice::from_raw_parts(self.alloc.ptr().as_ptr() as *const Cluster, self.len) }
     }
 }
 
 impl DerefMut for ClusterTable {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: 排他借用により既存のslice/ProbeResultがなく、全len個が初期化済み。
         unsafe {
             std::slice::from_raw_parts_mut(self.alloc.ptr().as_ptr() as *mut Cluster, self.len)
         }
@@ -138,23 +162,9 @@ impl TranspositionTable {
         }
 
         let chunk = len.div_ceil(threads);
-        let ptr = self.table.as_mut_ptr();
-
-        // スレッドを分割してゼロクリア（やねうら王の Tools::memclear 相当）
         std::thread::scope(|scope| {
-            for i in 0..threads {
-                let start = i * chunk;
-                if start >= len {
-                    break;
-                }
-                let end = (start + chunk).min(len);
-                let count = end - start;
-                let ptr_addr = unsafe { ptr.add(start) } as usize;
-
-                scope.spawn(move || unsafe {
-                    let ptr = ptr_addr as *mut Cluster;
-                    std::ptr::write_bytes(ptr, 0, count);
-                });
+            for clusters in self.table.chunks_mut(chunk) {
+                scope.spawn(move || clusters.fill_with(Cluster::new));
             }
         });
     }
@@ -170,52 +180,54 @@ impl TranspositionTable {
         self.generation8.load(Ordering::Relaxed)
     }
 
-    /// 置換表を検索（クラスター内は16bitキーでマッチング）
-    pub fn probe(&self, key: u64, pos: &Position) -> ProbeResult {
-        let side_to_move = pos.side_to_move();
-        let cluster = self.first_entry(key, side_to_move);
+    /// 置換表を検索（クラスター内は16bitキーでマッチング）。
+    /// 他スレッドが同じクラスターを操作中ならmissを返し、このprobeからの書込みも省略する。
+    pub fn probe(&self, key: u64, pos: &Position) -> ProbeResult<'_> {
+        let cluster = self.first_entry(key, pos.side_to_move());
+        let Some(guard) = cluster.try_lock() else {
+            return ProbeResult {
+                found: false,
+                data: TTData::EMPTY,
+                writer: None,
+            };
+        };
         let key16 = key as u16;
-
-        // クラスター内を検索（下位16bitキーでマッチング）
-        for entry in &cluster.entries {
+        let gen8 = self.generation();
+        let mut replace = 0;
+        let mut min_value = i32::MAX;
+        for index in 0..CLUSTER_SIZE {
+            let entry = guard.load(index);
             if entry.key16() == key16 {
                 let mut data = entry.read();
-
                 if data.mv != Move::NONE {
                     if let Some(m) = pos.to_move(data.mv) {
                         data.mv = m;
                     } else {
+                        // 不正な手を持つ同一短縮キーはヒットとして採用しない。
+                        let value = entry.depth8() as i32 - entry.relative_age(gen8) as i32;
+                        if value < min_value {
+                            min_value = value;
+                            replace = index;
+                        }
                         continue;
                     }
                 }
-
                 return ProbeResult {
                     found: entry.is_occupied(),
                     data,
-                    writer: entry as *const _ as *mut _,
+                    writer: Some((cluster, index)),
                 };
             }
-        }
-
-        // 置換するエントリを選択（価値が最小のもの）
-        let gen8 = self.generation();
-        let mut replace = cluster.entries.as_ptr() as *mut TTEntry;
-        let mut min_value = i32::MAX;
-
-        for entry in &cluster.entries {
-            // 置換価値 = depth8 - relative_age (YaneuraOu準拠)
             let value = entry.depth8() as i32 - entry.relative_age(gen8) as i32;
-
             if value < min_value {
                 min_value = value;
-                replace = entry as *const _ as *mut TTEntry;
+                replace = index;
             }
         }
-
         ProbeResult {
             found: false,
             data: TTData::EMPTY,
-            writer: replace,
+            writer: Some((cluster, replace)),
         }
     }
 
@@ -227,7 +239,11 @@ impl TranspositionTable {
         let sample_count = 1000.min(self.cluster_count);
 
         for cluster in self.table.iter().take(sample_count) {
-            for entry in &cluster.entries {
+            let Some(guard) = cluster.try_lock() else {
+                continue;
+            };
+            for index in 0..CLUSTER_SIZE {
+                let entry = guard.load(index);
                 if entry.is_occupied() && entry.relative_age(gen8) <= max_age_internal {
                     count += 1;
                 }
@@ -285,21 +301,41 @@ impl TranspositionTable {
     }
 }
 
-/// probe結果
-pub struct ProbeResult {
+/// probe結果。書込み先のテーブル借用が有効な間だけ使用できる。
+///
+/// 所有元の破棄後に書き込むことはできない。
+/// ```compile_fail,E0505
+/// use rshogi_core::{position::Position, tt::TranspositionTable, types::{Bound, Move, Value}};
+/// let tt = TranspositionTable::new(1);
+/// let pos = Position::new();
+/// let probe = tt.probe(1, &pos);
+/// drop(tt);
+/// probe.write(1, Value::ZERO, false, Bound::Exact, 1, Move::NONE, Value::ZERO, 0);
+/// ```
+///
+/// 未使用のwriterが残っている間はresizeできない。
+/// ```compile_fail,E0502
+/// use rshogi_core::{position::Position, tt::TranspositionTable, types::{Bound, Move, Value}};
+/// let mut tt = TranspositionTable::new(1);
+/// let pos = Position::new();
+/// let probe = tt.probe(1, &pos);
+/// tt.resize(2);
+/// probe.write(1, Value::ZERO, false, Bound::Exact, 1, Move::NONE, Value::ZERO, 0);
+/// ```
+pub struct ProbeResult<'a> {
     /// ヒットしたか
     pub found: bool,
     /// 読み取ったデータ
     pub data: TTData,
     /// 書き込み用エントリ
-    writer: *mut TTEntry,
+    writer: Option<(&'a Cluster, usize)>,
 }
 
-impl ProbeResult {
+impl ProbeResult<'_> {
     /// エントリに書き込む（内部で16bitに切り詰め）
     ///
-    /// # Safety
-    /// writerポインタが有効であることを前提とする
+    /// probe後の別writerによる更新を再読込し、排他下で置換条件を判定する。
+    /// 競合時はこの書込みを見送る。
     pub fn write(
         &self,
         key: u64,
@@ -311,10 +347,15 @@ impl ProbeResult {
         eval: Value,
         generation8: u8,
     ) {
-        // SAFETY: writerはprobe()で取得した有効なポインタ
-        unsafe {
-            (*self.writer).save(key, value, is_pv, bound, depth, mv, eval, generation8);
-        }
+        let Some((cluster, index)) = self.writer else {
+            return;
+        };
+        let Some(guard) = cluster.try_lock() else {
+            return;
+        };
+        let mut entry = guard.load(index);
+        entry.save(key, value, is_pv, bound, depth, mv, eval, generation8);
+        guard.store(index, entry);
     }
 }
 
@@ -329,6 +370,173 @@ impl TtPrefetch for TranspositionTable {
 mod tests {
     use super::*;
     use crate::position::{Position, SFEN_HIRATE};
+
+    #[test]
+    fn test_stale_writer_rechecks_latest_entry() {
+        let tt = TranspositionTable::new(0);
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let old_probe = tt.probe(1, &pos);
+        let mv = Move::from_usi("7g7f").unwrap();
+        tt.probe(2, &pos)
+            .write(2, Value::new(20), false, Bound::Exact, 20, mv, Value::ZERO, 0);
+        old_probe.write(1, Value::new(10), false, Bound::Lower, 10, Move::NONE, Value::ZERO, 0);
+        let replaced = tt.probe(1, &pos);
+        assert!(replaced.found);
+        assert_eq!(replaced.data.mv, Move::NONE, "different key must not inherit previous move");
+        tt.probe(1, &pos)
+            .write(1, Value::new(30), false, Bound::Exact, 30, mv, Value::ZERO, 0);
+        old_probe.write(1, Value::new(1), false, Bound::Lower, 1, Move::NONE, Value::ZERO, 0);
+        let preserved = tt.probe(1, &pos);
+        assert_eq!(preserved.data.value.raw(), 30, "save policy must use latest depth");
+        assert_eq!(preserved.data.mv.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn test_cluster_contention_skips_probe_and_write() {
+        let tt = TranspositionTable::new(0);
+        let pos = Position::new();
+        let writer = tt.probe(1, &pos);
+        let cluster = tt.first_entry(1, pos.side_to_move());
+        let guard = cluster.try_lock().unwrap();
+        assert!(!tt.probe(1, &pos).found);
+        writer.write(1, Value::new(99), false, Bound::Exact, 10, Move::NONE, Value::ZERO, 0);
+        assert!(!guard.load(0).is_occupied());
+        drop(guard);
+        writer.write(1, Value::new(99), false, Bound::Exact, 10, Move::NONE, Value::ZERO, 0);
+        assert_eq!(tt.probe(1, &pos).data.value.raw(), 99);
+    }
+
+    #[test]
+    fn test_competing_writers_publish_consistent_entries() {
+        use std::sync::{Arc, Barrier};
+        let tt = TranspositionTable::new(0);
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let barrier = Arc::new(Barrier::new(4));
+        std::thread::scope(|scope| {
+            for key in [1, 2] {
+                let barrier = Arc::clone(&barrier);
+                let tt = &tt;
+                let pos = &pos;
+                scope.spawn(move || {
+                    let mv = Move::from_usi(if key == 1 { "7g7f" } else { "2g2f" }).unwrap();
+                    barrier.wait();
+                    for _ in 0..10_000 {
+                        tt.probe(key, pos).write(
+                            key,
+                            Value::new(key as i32 * 100),
+                            key == 1,
+                            Bound::Exact,
+                            key as i32 * 10,
+                            mv,
+                            Value::new(-(key as i32)),
+                            0,
+                        );
+                    }
+                });
+            }
+            for _ in 0..2 {
+                let barrier = Arc::clone(&barrier);
+                let tt = &tt;
+                let pos = &pos;
+                scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..10_000 {
+                        for key in [1, 2] {
+                            let probe = tt.probe(key, pos);
+                            if probe.found {
+                                assert_eq!(probe.data.value.raw(), key as i32 * 100);
+                                assert_eq!(probe.data.eval.raw(), -(key as i32));
+                                assert_eq!(probe.data.depth, key as i32 * 10);
+                                assert_eq!(probe.data.is_pv, key == 1);
+                                assert_eq!(probe.data.bound, Bound::Exact);
+                                assert_eq!(
+                                    probe.data.mv.to_usi(),
+                                    if key == 1 { "7g7f" } else { "2g2f" }
+                                );
+                            }
+                        }
+                        assert!(tt.hashfull(0) >= 0);
+                    }
+                });
+            }
+        });
+        for key in [1, 2] {
+            tt.probe(key, &pos).write(
+                key,
+                Value::new(key as i32 * 100),
+                false,
+                Bound::Exact,
+                10,
+                Move::NONE,
+                Value::ZERO,
+                0,
+            );
+            assert!(tt.probe(key, &pos).found);
+        }
+    }
+
+    #[test]
+    fn test_snapshot_replacement_capacity_and_clear() {
+        let mut tt = TranspositionTable::new(1);
+        let mut pos = Position::new();
+        pos.set_hirate();
+        assert_eq!(tt.cluster_count * CLUSTER_SIZE, 98_304);
+        for key in 1..=3 {
+            tt.probe(key, &pos).write(
+                key,
+                Value::new(key as i32),
+                false,
+                Bound::Exact,
+                key as i32 * 10,
+                Move::NONE,
+                Value::ZERO,
+                0,
+            );
+        }
+        for key in 1..=3 {
+            assert!(tt.probe(key, &pos).found);
+        }
+        tt.probe(4, &pos).write(
+            4,
+            Value::ZERO,
+            false,
+            Bound::Exact,
+            40,
+            Move::NONE,
+            Value::ZERO,
+            0,
+        );
+        assert!(!tt.probe(1, &pos).found, "shallowest entry must be replaced");
+        tt.new_search();
+        tt.probe(2, &pos).write(
+            2,
+            Value::ZERO,
+            false,
+            Bound::Exact,
+            1,
+            Move::NONE,
+            Value::ZERO,
+            tt.generation(),
+        );
+        tt.probe(5, &pos).write(
+            5,
+            Value::ZERO,
+            false,
+            Bound::Exact,
+            1,
+            Move::NONE,
+            Value::ZERO,
+            tt.generation(),
+        );
+        // depth-age: key2=2、key3=31-8、key4=41-8。
+        assert!(!tt.probe(2, &pos).found);
+        tt.clear();
+        for key in 1..=5 {
+            assert!(!tt.probe(key, &pos).found);
+        }
+    }
 
     #[test]
     fn test_tt_new() {

--- a/crates/rshogi-core/src/tt/table.rs
+++ b/crates/rshogi-core/src/tt/table.rs
@@ -335,7 +335,8 @@ impl ProbeResult<'_> {
     /// エントリに書き込む（内部で16bitに切り詰め）
     ///
     /// probe後の別writerによる更新を再読込し、排他下で置換条件を判定する。
-    /// 競合時はこの書込みを見送る。
+    /// probe時または書込み時の競合で見送った場合はfalse、置換条件を適用して格納した場合はtrueを返す。
+    /// trueでも置換条件により既存の値が保持されることがある。
     pub fn write(
         &self,
         key: u64,
@@ -346,16 +347,17 @@ impl ProbeResult<'_> {
         mv: Move,
         eval: Value,
         generation8: u8,
-    ) {
+    ) -> bool {
         let Some((cluster, index)) = self.writer else {
-            return;
+            return false;
         };
         let Some(guard) = cluster.try_lock() else {
-            return;
+            return false;
         };
         let mut entry = guard.load(index);
         entry.save(key, value, is_pv, bound, depth, mv, eval, generation8);
         guard.store(index, entry);
+        true
     }
 }
 
@@ -386,7 +388,16 @@ mod tests {
         assert_eq!(replaced.data.mv, Move::NONE, "different key must not inherit previous move");
         tt.probe(1, &pos)
             .write(1, Value::new(30), false, Bound::Exact, 30, mv, Value::ZERO, 0);
-        old_probe.write(1, Value::new(1), false, Bound::Lower, 1, Move::NONE, Value::ZERO, 0);
+        assert!(old_probe.write(
+            1,
+            Value::new(1),
+            false,
+            Bound::Lower,
+            1,
+            Move::NONE,
+            Value::ZERO,
+            0
+        ));
         let preserved = tt.probe(1, &pos);
         assert_eq!(preserved.data.value.raw(), 30, "save policy must use latest depth");
         assert_eq!(preserved.data.mv.to_usi(), "7g7f");
@@ -399,12 +410,78 @@ mod tests {
         let writer = tt.probe(1, &pos);
         let cluster = tt.first_entry(1, pos.side_to_move());
         let guard = cluster.try_lock().unwrap();
-        assert!(!tt.probe(1, &pos).found);
-        writer.write(1, Value::new(99), false, Bound::Exact, 10, Move::NONE, Value::ZERO, 0);
+        let skipped_probe = tt.probe(1, &pos);
+        assert!(!skipped_probe.found);
+        assert!(!writer.write(
+            1,
+            Value::new(99),
+            false,
+            Bound::Exact,
+            10,
+            Move::NONE,
+            Value::ZERO,
+            0
+        ));
         assert!(!guard.load(0).is_occupied());
         drop(guard);
-        writer.write(1, Value::new(99), false, Bound::Exact, 10, Move::NONE, Value::ZERO, 0);
+        assert!(!skipped_probe.write(
+            1,
+            Value::new(99),
+            false,
+            Bound::Exact,
+            10,
+            Move::NONE,
+            Value::ZERO,
+            0
+        ));
+        assert!(!tt.probe(1, &pos).found);
+        assert!(writer.write(
+            1,
+            Value::new(99),
+            false,
+            Bound::Exact,
+            10,
+            Move::NONE,
+            Value::ZERO,
+            0
+        ));
         assert_eq!(tt.probe(1, &pos).data.value.raw(), 99);
+    }
+
+    #[test]
+    fn test_probe_contention_writer_stays_skipped_after_unlock() {
+        let tt = TranspositionTable::new(0);
+        let pos = Position::new();
+        assert!(tt.probe(1, &pos).write(
+            1,
+            Value::new(99),
+            false,
+            Bound::Exact,
+            10,
+            Move::NONE,
+            Value::ZERO,
+            0,
+        ));
+        let cluster = tt.first_entry(1, pos.side_to_move());
+        let guard = cluster.try_lock().unwrap();
+        let skipped_probe = tt.probe(1, &pos);
+        assert!(!skipped_probe.found);
+        drop(guard);
+
+        assert!(!skipped_probe.write(
+            1,
+            Value::new(42),
+            false,
+            Bound::Exact,
+            20,
+            Move::NONE,
+            Value::ZERO,
+            0,
+        ));
+        let preserved = tt.probe(1, &pos);
+        assert!(preserved.found);
+        assert_eq!(preserved.data.value.raw(), 99);
+        assert_eq!(preserved.data.depth, 10);
     }
 
     #[test]

--- a/crates/rshogi-core/src/tt/table.rs
+++ b/crates/rshogi-core/src/tt/table.rs
@@ -337,6 +337,10 @@ impl ProbeResult<'_> {
     /// probe後の別writerによる更新を再読込し、排他下で置換条件を判定する。
     /// probe時または書込み時の競合で見送った場合はfalse、置換条件を適用して格納した場合はtrueを返す。
     /// trueでも置換条件により既存の値が保持されることがある。
+    ///
+    /// 戻り値を捨てる呼び出しは、格納の成否に依存する記録 (統計・トレース) を
+    /// 伴わないことを `let _ =` で明示する。
+    #[must_use]
     pub fn write(
         &self,
         key: u64,
@@ -380,14 +384,39 @@ mod tests {
         pos.set_hirate();
         let old_probe = tt.probe(1, &pos);
         let mv = Move::from_usi("7g7f").unwrap();
-        tt.probe(2, &pos)
-            .write(2, Value::new(20), false, Bound::Exact, 20, mv, Value::ZERO, 0);
-        old_probe.write(1, Value::new(10), false, Bound::Lower, 10, Move::NONE, Value::ZERO, 0);
+        assert!(tt.probe(2, &pos).write(
+            2,
+            Value::new(20),
+            false,
+            Bound::Exact,
+            20,
+            mv,
+            Value::ZERO,
+            0
+        ));
+        assert!(old_probe.write(
+            1,
+            Value::new(10),
+            false,
+            Bound::Lower,
+            10,
+            Move::NONE,
+            Value::ZERO,
+            0
+        ));
         let replaced = tt.probe(1, &pos);
         assert!(replaced.found);
         assert_eq!(replaced.data.mv, Move::NONE, "different key must not inherit previous move");
-        tt.probe(1, &pos)
-            .write(1, Value::new(30), false, Bound::Exact, 30, mv, Value::ZERO, 0);
+        assert!(tt.probe(1, &pos).write(
+            1,
+            Value::new(30),
+            false,
+            Bound::Exact,
+            30,
+            mv,
+            Value::ZERO,
+            0
+        ));
         assert!(old_probe.write(
             1,
             Value::new(1),
@@ -500,7 +529,8 @@ mod tests {
                     let mv = Move::from_usi(if key == 1 { "7g7f" } else { "2g2f" }).unwrap();
                     barrier.wait();
                     for _ in 0..10_000 {
-                        tt.probe(key, pos).write(
+                        // 競合時の skip 自体が検証対象なので、ここでは成否を問わない。
+                        let _ = tt.probe(key, pos).write(
                             key,
                             Value::new(key as i32 * 100),
                             key == 1,
@@ -540,7 +570,7 @@ mod tests {
             }
         });
         for key in [1, 2] {
-            tt.probe(key, &pos).write(
+            assert!(tt.probe(key, &pos).write(
                 key,
                 Value::new(key as i32 * 100),
                 false,
@@ -549,7 +579,7 @@ mod tests {
                 Move::NONE,
                 Value::ZERO,
                 0,
-            );
+            ));
             assert!(tt.probe(key, &pos).found);
         }
     }
@@ -561,7 +591,7 @@ mod tests {
         pos.set_hirate();
         assert_eq!(tt.cluster_count * CLUSTER_SIZE, 98_304);
         for key in 1..=3 {
-            tt.probe(key, &pos).write(
+            assert!(tt.probe(key, &pos).write(
                 key,
                 Value::new(key as i32),
                 false,
@@ -570,12 +600,12 @@ mod tests {
                 Move::NONE,
                 Value::ZERO,
                 0,
-            );
+            ));
         }
         for key in 1..=3 {
             assert!(tt.probe(key, &pos).found);
         }
-        tt.probe(4, &pos).write(
+        assert!(tt.probe(4, &pos).write(
             4,
             Value::ZERO,
             false,
@@ -584,10 +614,10 @@ mod tests {
             Move::NONE,
             Value::ZERO,
             0,
-        );
+        ));
         assert!(!tt.probe(1, &pos).found, "shallowest entry must be replaced");
         tt.new_search();
-        tt.probe(2, &pos).write(
+        assert!(tt.probe(2, &pos).write(
             2,
             Value::ZERO,
             false,
@@ -596,8 +626,8 @@ mod tests {
             Move::NONE,
             Value::ZERO,
             tt.generation(),
-        );
-        tt.probe(5, &pos).write(
+        ));
+        assert!(tt.probe(5, &pos).write(
             5,
             Value::ZERO,
             false,
@@ -606,7 +636,7 @@ mod tests {
             Move::NONE,
             Value::ZERO,
             tt.generation(),
-        );
+        ));
         // depth-age: key2=2、key3=31-8、key4=41-8。
         assert!(!tt.probe(2, &pos).found);
         tt.clear();
@@ -655,7 +685,7 @@ mod tests {
         assert!(!probe1.found);
 
         // 書き込み
-        probe1.write(
+        assert!(probe1.write(
             key,
             Value::new(50),
             true,
@@ -664,7 +694,7 @@ mod tests {
             Move::NONE,
             Value::ZERO,
             tt.generation(),
-        );
+        ));
 
         // 2回目はヒット
         let probe2 = tt.probe(key, &pos);
@@ -708,7 +738,7 @@ mod tests {
 
         // 書き込み（DEPTH_ENTRY_OFFSETを考慮して有効な深さ）
         let probe1 = tt.probe(key, &pos);
-        probe1.write(
+        assert!(probe1.write(
             key,
             Value::new(100),
             false,
@@ -717,7 +747,7 @@ mod tests {
             Move::NONE,
             Value::ZERO,
             tt.generation(),
-        );
+        ));
 
         // クリア
         tt.clear();

--- a/docs/performance/20260909_tt_atomic_safety.md
+++ b/docs/performance/20260909_tt_atomic_safety.md
@@ -1,55 +1,210 @@
-# TT atomic snapshot / writer lifetime 検証（2026-09-09）
+# TT relaxed atomic / writer lifetime 検証
 
-## 変更と契約
+## 設計と契約
 
-共有テーブルは AtomicU16 × 5 の10バイト格納を使い、3エントリと1バイトの
-Acquire/Release排他、1バイトのpaddingを32バイトclusterに収める。公開TTEntryは
-従来どおり所有されたsnapshotで、置換条件の計算に使用する。
+`Cluster` は `data: [AtomicU64; 3]`、`keys: [AtomicU16; 3]`、
+2バイトのpaddingを持つSoA配置。32バイト境界とサイズのcompile-time assertを維持し、
+1 MiB当たり32,768 cluster / 98,304 entryの容量は変わらない。
+所有snapshotの `TTEntry` は10バイトのまま。チェックサム方式は使用しない。
 
-probe/read/hashfull/writeは短いcluster排他の内側でsnapshotを読み書きする。
-probe結果はロックを持ち越さず、write時に最新snapshotから置換条件を再評価する。
-競合中のprobeはmiss（そのwriterも書込み省略）、writeは省略する。spin待機しないため
-探索の停止応答をロック待機に依存させない。競合によってcache利用と探索木は変わり得る。
-new_searchの世代は独立atomicを維持する。clear/resizeは排他借用を要求し、
-ProbeResultはテーブル借用に結び付くため、生存writerと共存できない。
+payloadの下位からdepth8、generation/PV/bound8、move16、value16、eval16を
+64bitへ符号化する。符号付き値はu16経由でビット列を保持する。
+probe/hashfull/writeはRelaxedでアクセスし、snapshotのload/storeはそれぞれ
+5回のAtomicU16アクセスからAtomicU16とAtomicU64の2回になる。
+writeは再読込と格納を行うため合計4回。クラスタロック、待機、競合によるskipはない。
+payload内の対応は単一store/loadで保たれるが、keyとの一貫性は保証しない。
+probeは所有値のsnapshotを返し、writerは常に借用したclusterとslotを持つ。
+生ポインタからの可変entry参照は作らない。clear/resizeは排他借用を要求し、
+drop/resize後のwriter使用を拒否するcompile-fail doctestを維持する。
 
-## 検証
+probeの置換候補は従来の `depth8 - relative_age`、writeはslotを再読込して
+`TTEntry::save` のExact・異key・depth/PV・generation条件を適用する。
+条件式と同一keyの手の保持規則は変更していない。ただし並行writer間での
+判定と格納は不可分ではなく、古いsnapshotの再格納や深い結果の上書きは起こり得る。
+これはロックによる直列化を外すことに伴う制約である。
 
-- 通常probe/write、3slot容量、depth-age置換、世代、clear/resize。
-- stale writerが別keyへ置換されたslotを再評価し、同じkeyの新しい深い結果を保存条件で保護。
-- 2writer + 2readerの同一cluster負荷でkey/value/eval/depth/bound/PV/手の整合性。
-- 排他取得失敗時のmiss/書込み省略、解放後の利用再開。
-- drop/resize後のwriter利用を拒否するcompile-fail doctest 2件。
-- ThreadSanitizerでTT関連18テストを通過（sanitizer対象外の実対局全体の保証ではない）。
+`write -> bool` と `#[must_use]` は維持する。falseになる条件はなく、trueは
+「置換条件を適用した格納操作が完了した」を表す。値の変更や、その後の上書きがないこと、
+複数wordの同時公開を意味しない。置換条件で既存値を保持してもtrueなのは従来と同じ。
+戻り値は現在の実装では情報量がなく冗長だが、成否APIと呼出側の記録契約を維持するため残す。
+`alpha_beta.rs` / `eval_helpers.rs` / `pruning.rs` / `qsearch.rs` の成功時のみ
+統計・トレースを計上する分岐は維持。記録は格納操作の入力であり、後続probeの観測値を保証しない。
+
+## torn entryの防御と限界
+
+**メモリ上のdata raceを防ぐことと、探索結果が影響を受けないことは別である。
+この設計でtorn entryが探索に無害とは保証できない。**
+
+実際のコード上の検証経路:
+
+- `tt/table.rs::probe`: 読み取った `key16` と検索keyの下位16bitを照合する。
+  異なる短縮キーは除外するが、keyと他wordの対応は検証しない。
+- `position/pos.rs::to_move`: `Move::from_u16_checked` で符号化を検証し、
+  通常手の移動元の駒・手番・成れる駒種を確認する。不整合ならprobeはそのslotを除外する。
+  移動規則、打ち駒の持ち駒、自玉の安全までは検証しない。`Move::NONE` は検査対象外。
+- `search/movepicker.rs` の通常・王手回避・qsearch・ProbCut用初期化で
+  `pseudo_legal_with_all` を適用する。`alpha_beta.rs` の探索ループは
+  `pseudo_legal` と `is_legal`、`qsearch.rs` と `pruning.rs` のループは
+  `is_legal` を実行してから着手する。この経路には合法性検査が実在するため追加しない。
+- `search/eval_helpers.rs` と `qsearch.rs` のTT cutoffは、その着手検査より前に行われる。
+  `tt_sanity.rs` のvalue/eval範囲検査は範囲外を弾くだけで、別探索由来の有効値は弾けない。
+
+payload内のvalue/bound/depthが別storeから混在することはない。残る最悪ケースは、
+要求keyに別keyのpayloadが対応し、誤ったfail-high/fail-lowや詰みスコアを返すこと。その結果は親局面へ伝播し、探索木、
+PV、最善手や棋力に影響し得る。合法なTT手でも発生し、手がNONEでもcutoffし得る。
+通常設定のeager NNUEもTT valueによるcutoffまでは無効化しない。
+
+確率は次のように分ける必要がある。
+
+- 独立一様な無関係の短縮キーを仮定すると、1slotの偶然一致は
+  `1/65536 ≈ 0.001526%`、3slotの和の上界は `3/65536 ≈ 0.004578%`。
+  これは通常の短縮キー衝突の見積りであり、全probeに対する誤cutoff率ではない。
+- 同一keyへの並行更新ではkey照合の通過率は100%。異keyへの置換中でも、
+  要求したkeyと別書込みのdataが見えれば通過する。ここに一律 `1/65536` は掛けられない。
+- probeが不整合snapshotを読む確率を `q`、その条件下でkey/手/範囲/depth/boundの
+  検査を通って誤cutoffする確率を `r` とすれば、その寄与は `q × r`。
+  実探索のq/rは未計測であり、数値の上限として1より有用な保証は得ていない。
+  並行writerが混合状態を残すと、書込み終了後のprobeでも影響を受け得る。
+  書込み時間窓だけからqを推定することもできない。
+
+SoAでもkeyとpayloadは同一32バイトcluster内にあり、64バイトcache lineを跨がない。
+key→payloadのload/store順は維持するが、Relaxedは両者を同時公開しない。
+アクセス回数と配置が変わるため混在する時間窓・頻度は変わり得る。
+payload内の混在可能性は減る一方、key/payload混在の実測頻度が減るとは断定しない。
+異keyのwriterが交錯すれば混合状態が残る点も同じである。
+write時に混在snapshotで置換判定する可能性も残り、単一payload化は探索結果の整合性証明ではない。
+
+したがって小さい通常キー衝突率やTSan通過を、torn entryの無害性・棋力の証拠には使わない。
+無害性まで必須ならこの方式だけでは満たせない。全手の合法性検査をprobeへ移しても
+value/boundの対応は証明できず、別途一貫性検証またはTT値の利用制限が必要になる。
+
+## SoA実装の検証
+
+- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings`: 通過。
+- `cargo clippy --fix --allow-dirty --tests`: sandbox内のTCP listener bindがEPERM。
+  自動修正は実行できなかったが、上記の通常Clippyは警告ゼロ。
+- `cargo test`: CSA clientの `csa_entering_king_rule` 5件がTCP bindのEPERMで失敗。
+  workspace全体のgateは未達で、TCP bindが許可された環境で再実行が必要。
+- `cargo test -p rshogi-core`: unit 1,051件、通常doctest 40件、
+  drop/resizeのcompile-fail doctest 2件が通過（計16件ignored）。
+- `tt-trace,search-stats` 有効のcore全対象ClippyとTTテスト20件: 通過。
+- build-std付きThreadSanitizer: TTテスト20件通過。コマンドは後掲と同じ。
+- `bash scripts/check-tracked-abs-paths.sh` / `git diff --check`: 通過。
+
+payloadの符号・ビット境界のroundtrip、同一slotの2writer/2readerによるpayload内の
+対応、keyだけ異なる混合状態でのprobe/cutoffの限界を検証した。
+容量・置換・世代・stale writerの再評価・clear/resizeのテストも維持した。
+
+### 決定性と性能計測の状態
+
+比較用baseは `git archive 0d4c3b64` を一時領域へ展開し、candidateとともに
+`cargo xtask build --edition edition-layerstacks-halfka_hm_merged-1536x16x32-none`
+でビルドした。worktreeの追加はしていない。
+
+LS 1536x16x32の指定net、kingrank9、1T、Hash 16MBで、次の4局面を
+それぞれ独立processの `go depth 8` で比較した。
+全局面のdepth 1〜8でnodes、score、PV、最終bestmoveがbaseと一致した。
+最終nodesは順に1,167,105 / 66,251 / 26,862 / 119,634。
+これは決定性の確認であり、速度の測定結果ではない。
+
+```text
+startpos
+startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e 8d8e 2e2d 2c2d
+sfen 8l/1l+R2P3/p2pBG1pp/kps1p4/Nn1P2G2/P1P1P2PP/1PS6/1KSG3+r1/LN2+p3L w Sbgn3p 124
+startpos moves 7g7f 8c8d 2g2f 8d8e 2f2e 4a3b
+```
+
+### search_only_ab によるbase比（1T）
+
+同一機で他プロセスのビルドが走ると測定が汚染されるため、load averageが2を下回るまで
+待ってから実行した。4局面、movetime 3000ms、abba、rounds 3（各24 run）、CPU pin。
+
+| 実装 | NPS | cycles/node | instructions/node |
+|---|---|---|---|
+| ロックあり | -0.99% 〜 -1.38% | +0.78% 〜 +0.85% | +0.54% 〜 +0.60% |
+| 5-word lockless | -0.55% | +0.46% | +0.46% |
+| SoA lockless | **-0.17%** | **+0.26%** | **+0.32%** |
+
+SoA計測時のbaseline cycles/nodeは5828.5で、別セッションで取得した5825.0 / 5830.0と
+0.06%以内に一致する。対照条件が動いていないことの確認として記録する。
+ロックあり実装の-1.38%側はbaseline cycles/nodeが6002.1で、同一条件の他runより約3%高い。
+測定中に負荷が上がったとみられ、-0.99%側より信頼度が低い。
+
+atomicアクセスを1エントリあたり5回から2回へ削減したSoAで、instructions/nodeは
++0.46%から+0.32%へ下がった。NPSはbaseとの差が測定精度に埋もれる水準になった。
+
+静かな環境で、上記4行をpositionsファイルとして次を実行する。
+過去の4局面セットの内容は今回提示されていないため、過去の比率との直接比較には
+その局面セットを揃える必要がある。
 
 ```sh
-cargo test -p rshogi-core --lib tt::
-cargo test -p rshogi-core --doc
+uptime
+./target/release/search_only_ab \
+  --baseline /path/to/base/engines/rshogi-usi-layerstacks-halfka_hm_merged-1536x16x32-none \
+  --candidate ./engines/rshogi-usi-layerstacks-halfka_hm_merged-1536x16x32-none \
+  --positions /path/to/positions.txt --movetime-ms 3000 --pattern abba --rounds 2 \
+  --threads 1 --hash-mb 16 --cpu 2 \
+  --eval-file "$SHOGI_DATA/nnue/20260713-wrm-n2s1200-1536x16x32/ls-1536x16x32-halfka-hm-merged-wrm-n2s1200-400.bin" \
+  --usi-option LS_BUCKET_MODE=kingrank9
+```
+
+検証ログ・決定性比較JSON/スクリプトはローカル一時領域の `tt-soa-*` に保存した。
+
+## 5-word lockless実装の既存検証（SoA変更前）
+
+- `cargo fmt` と `git diff --check`: 通過。
+- `cargo clippy --workspace --all-targets -- -D warnings`: 警告ゼロで通過。
+- `cargo clippy --fix --allow-dirty --tests`: 内部ロック用TCP listenerのbindが
+  sandboxの `Operation not permitted (os error 1)` で失敗。通常Clippyで警告ゼロを確認した。
+- `cargo test`: CSA clientの `csa_entering_king_rule` の5テストがTCP bindのEPERMで失敗。
+  続けて `cargo test --workspace --no-fail-fast` で全対象を実行し、CSA client/server TCP関連の
+  8ターゲット・97テストが同じEPERMで失敗した。他の対象は通過したが、全workspace通過とは扱わない。
+- `cargo test -p rshogi-core`: 通過。drop/resizeを拒否するcompile-fail doctest 2件も通過。
+- `tt-trace,search-stats` を有効にしたcore全対象ClippyとTTテスト: 通過。
+- `bash scripts/check-tracked-abs-paths.sh`: 通過。
+- ThreadSanitizer: build-std付きでTT関連19テスト通過。TSanの対象はTTテストであり実対局全体ではない。
+
+テストは容量、通常probe/write、置換・世代・clear/resize、stale writer再評価を維持。
+ロック競合時のskipテストは撤去。同じslotへ固定した2writerと2readerの負荷で、
+全writeの完了とword単位の値域を検証する。word間の整合性を要求するテストは置かない。
+別に混合wordを明示的に作るテストと、key不一致・移動元不整合の除外、
+probeを通る疑似非合法手とvalue/boundのcutoff判定の限界を固定するテストを追加した。
+
+```sh
+cargo test -p rshogi-core
+cargo clippy -p rshogi-core --all-targets --features tt-trace,search-stats -- -D warnings
+cargo test -p rshogi-core --lib --features tt-trace,search-stats tt::
+# 未導入環境では rustup component add rust-src --toolchain nightly
 RUSTFLAGS=-Zsanitizer=thread CARGO_TARGET_DIR=target-tsan \
   cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
   -p rshogi-core --lib tt::
 ```
 
-Sanitizer実行環境: rustc 1.95.0-nightly (c04308580 2026-02-18)、rust-src導入済み。
-全workspaceのcargo test、Clippy、fmt、tracked絶対パス検査も通過。
+Sanitizerは既存のrustc 1.95.0-nightly (c04308580 2026-02-18) / rust-srcを使用。通常buildはrustc 1.95.0
+(59807616e 2026-04-14)。検証ログはローカル一時領域の `tt-unlocked-*.log` に保存した。
 
-## 限定した固定時間比較
+## 5-word lockless実装の既存固定時間ABBA比較
 
-baseline: `0d4c3b644`、比較対象: 本PRのatomic/lifetime修正。
-AMD Ryzen 9 5950X、Linux x86_64、rustc 1.97.1 (8bab26f4f 2026-07-14)。
-同じrelease設定（LTO off / codegen-units 16、target-cpu=native）で両方をbuildした。
-独立processごとにMaterialLevel=9、USI_Hash=16、Threads=1または2を設定。
-各局面でbase→patch→patch→baseの順に`go movetime 1000`。
-各探索の最終infoのnodesを足した値を示す。CPU固定・周波数固定・専有はしていない。
+以下は過去のmovetime方式の記録で、SoAの性能値ではない。外部build/test負荷の
+混入が疑われ、特に2Tの0.9017は静かな環境で再現できなかったと報告されている。
+0.5%程度の差の判定には使用せず、探索区間の `search_only_ab` を用いる。
 
-| Threads | base nodes（6探索合計） | patch nodes（6探索合計） | patch/base |
-|---|---:|---:|---:|
-| 1 | 3,864,926 | 3,747,142 | 0.9695 |
-| 2 | 7,374,983 | 7,079,358 | 0.9599 |
+baselineは `0d4c3b64` のgit archiveから新規buildし、本実装も同じ設定でbuildした。
+AMD Ryzen 9 5950X / Linux x86_64 / rustc 1.95.0。
+release、LTO off、codegen-units 16、target-cpu=native、その他はCargo既定値。
 
-この短いMaterial評価での比較では約3–4%のnodes減少を観測した。
-本番NNUE、長い持時間、多数スレッド、棋力の採否を示す測定ではない。
-固定時間SPRT等の正式な採否検定は実施していない。
+```sh
+CARGO_PROFILE_RELEASE_LTO=off CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
+  cargo build --release -p rshogi-usi
+```
+
+各探索は独立processで `usi` → `usiok` → MaterialLevel=9 / USI_Hash=16 /
+Threads=1または2 → `isready` → `readyok` → `position` → `go movetime 1000`
+→ `bestmove` → `quit` の順。最終infoのnodesを集計する。
+1Tは `taskset -c 4`、2Tは `taskset -c 4,5`（別物理core）に固定。
+3局面それぞれでbase→patch→patch→baseを5反復、各Threads・各実装30探索。
+反復→Threads (1,2)→局面→ABBAの順で実行し、計測中はこの作業のbuild/testを走らせない。
+周波数固定・CPU専有はしていない。
 
 使用局面（USI position引数）:
 
@@ -59,13 +214,62 @@ startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e 8d8e 2e2d 2c2d
 sfen 8l/1l+R2P3/p2pBG1pp/kps1p4/Nn1P2G2/P1P1P2PP/1PS6/1KSG3+r1/LN2+p3L w Sbgn3p 124
 ```
 
-別にThreads=1、同じ3局面を`go depth 5`で比較すると、nodesは順に2009 / 546 / 6189で一致し、
-score・PV・bestmoveも一致した。これは決定性回帰の確認で、速度・棋力の証拠には使わない。
+| Threads | base nodes（30探索） | patch nodes（30探索） | patch/base | bootstrap 95%区間 |
+|---|---:|---:|---:|---:|
+| 1 | 19,211,548 | 18,527,677 | 0.9644 | 0.9602–0.9689 |
+| 2 | 36,621,716 | 33,020,337 | 0.9017 | 0.8318–0.9741 |
 
-## 競合頻度の限定観測
+**この旧計測だけではbase比の性能劣化を判定できない。** 1Tは約3.56%、2Tは約9.83%のnodes減を観測した。
+2Tのブロック比は0.620–1.332と変動が大きい。ロック撤去だけで速度問題が解消したとは言えず、
+残るatomic格納・snapshot処理のコストと外部負荷・探索木の影響の切り分けは未実施。
 
-事前にkey1/2を同じclusterに保存し、2writer + 2readerがその2keyだけを10万回ずつprobeする
-独立harnessでは、400,000 probeのうち367,345（91.84%）が排他競合でmissした。
-writer側のprobe missは184,640で、これらはwriteも省略される。probe成功後のwrite時競合は
-別途数えておらず、書込み省略数は下限のみ。実探索の競合頻度は未計測。
-これは単一clusterに負荷を集中させた意図的な極端条件であり、通常のcache hit率を表さない。
+区間は各局面の5個のABBAブロックを復元抽出する層別bootstrap（10,000回、
+Python Random seed=1044、合計nodesの比、昇順の250番目/9,750番目）による記述的な推定。
+時系列の独立性や正規性を実証した正式な採否検定ではない。
+
+再集計用のABBAブロック合計（各セルはbase / patchの各2探索合計）:
+
+| 反復 | 局面（上記順） | 1T base / patch | 2T base / patch |
+|---|---|---:|---:|
+| 1 | 1 | 1360232 / 1313864 | 2404432 / 2311925 |
+| 1 | 2 | 1196929 / 1174614 | 2288856 / 2183366 |
+| 1 | 3 | 1257269 / 1208023 | 2492957 / 2174789 |
+| 2 | 1 | 1264318 / 1227679 | 2488575 / 2416778 |
+| 2 | 2 | 1102410 / 1061935 | 2445899 / 2335466 |
+| 2 | 3 | 1268399 / 1224696 | 2598453 / 2367845 |
+| 3 | 1 | 1371842 / 1301260 | 1776728 / 2367247 |
+| 3 | 2 | 1233776 / 1187779 | 2426285 / 2318341 |
+| 3 | 3 | 1335759 / 1283404 | 2552610 / 2562624 |
+| 4 | 1 | 1366563 / 1308128 | 2505191 / 1597572 |
+| 4 | 2 | 1207521 / 1191520 | 2422822 / 2348452 |
+| 4 | 3 | 1344338 / 1278989 | 2639688 / 2290548 |
+| 5 | 1 | 1369076 / 1306735 | 2451495 / 1519248 |
+| 5 | 2 | 1227173 / 1185262 | 2441346 / 1810030 |
+| 5 | 3 | 1305943 / 1273789 | 2686379 / 2416106 |
+
+別に各実装1回、1Tの `go depth 5` を同じ3局面で実行。nodesは2009 / 546 / 6189、
+score/PV/bestmoveも一致した。速度や棋力の証拠には使わない。
+全processは正常終了。個別nodes・最終info・wall timeを `tt-unlocked-bench.json`、
+実行スクリプトを `tt-unlocked-bench.py`、標準エラーを `tt-unlocked-bench-*.stderr` として
+ローカル一時領域へ保存した。base/patchの依存Cargo.lockも一致を確認した。
+
+この比較は短いMaterial評価・固定時間の探索量を対象とする。特に2Tのnodesは
+探索木の変化も含み、命令実行コストのみを分離できない。本番NNUE、長時間、多数スレッド、
+棋力は未検証。小標本の信頼区間はCPU負荷・周波数変動・局面選択バイアスを保証しない。
+棋力の採否判定やSPRTは実施していない。
+
+## ロックあり実装の既存記録
+
+以下は撤去したロックあり実装の記録であり、本実装の測定値ではない。
+同じbase、MaterialLevel=9、Hash=16、3局面、movetime 1000、ABBA各1回、CPU固定なし。
+当時はrustc 1.97.1、LTO off / codegen-units 16 / target-cpu=native。
+
+| Threads | base nodes（6探索） | ロックあり nodes（6探索） | 比 |
+|---|---:|---:|---:|
+| 1 | 3,864,926 | 3,747,142 | 0.9695 |
+| 2 | 7,374,983 | 7,079,358 | 0.9599 |
+
+同一clusterの2keyに2writer + 2reader各10万probeを集中させた旧harnessでは、
+400,000 probe中367,345（91.84%）が排他競合でmissし、writer側probe missは184,640。
+probe成功後のwrite競合は未集計だった。この極端負荷は実探索の競合率を示さない。
+当時の1T depth 5の3局面はnodes 2009 / 546 / 6189、score/PV/bestmoveがbaseと一致した。

--- a/docs/performance/20260909_tt_atomic_safety.md
+++ b/docs/performance/20260909_tt_atomic_safety.md
@@ -1,0 +1,71 @@
+# TT atomic snapshot / writer lifetime 検証（2026-09-09）
+
+## 変更と契約
+
+共有テーブルは AtomicU16 × 5 の10バイト格納を使い、3エントリと1バイトの
+Acquire/Release排他、1バイトのpaddingを32バイトclusterに収める。公開TTEntryは
+従来どおり所有されたsnapshotで、置換条件の計算に使用する。
+
+probe/read/hashfull/writeは短いcluster排他の内側でsnapshotを読み書きする。
+probe結果はロックを持ち越さず、write時に最新snapshotから置換条件を再評価する。
+競合中のprobeはmiss（そのwriterも書込み省略）、writeは省略する。spin待機しないため
+探索の停止応答をロック待機に依存させない。競合によってcache利用と探索木は変わり得る。
+new_searchの世代は独立atomicを維持する。clear/resizeは排他借用を要求し、
+ProbeResultはテーブル借用に結び付くため、生存writerと共存できない。
+
+## 検証
+
+- 通常probe/write、3slot容量、depth-age置換、世代、clear/resize。
+- stale writerが別keyへ置換されたslotを再評価し、同じkeyの新しい深い結果を保存条件で保護。
+- 2writer + 2readerの同一cluster負荷でkey/value/eval/depth/bound/PV/手の整合性。
+- 排他取得失敗時のmiss/書込み省略、解放後の利用再開。
+- drop/resize後のwriter利用を拒否するcompile-fail doctest 2件。
+- ThreadSanitizerでTT関連18テストを通過（sanitizer対象外の実対局全体の保証ではない）。
+
+```sh
+cargo test -p rshogi-core --lib tt::
+cargo test -p rshogi-core --doc
+RUSTFLAGS=-Zsanitizer=thread CARGO_TARGET_DIR=target-tsan \
+  cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+  -p rshogi-core --lib tt::
+```
+
+Sanitizer実行環境: rustc 1.95.0-nightly (c04308580 2026-02-18)、rust-src導入済み。
+全workspaceのcargo test、Clippy、fmt、tracked絶対パス検査も通過。
+
+## 限定した固定時間比較
+
+baseline: `0d4c3b644`、比較対象: 本PRのatomic/lifetime修正。
+AMD Ryzen 9 5950X、Linux x86_64、rustc 1.97.1 (8bab26f4f 2026-07-14)。
+同じrelease設定（LTO off / codegen-units 16、target-cpu=native）で両方をbuildした。
+独立processごとにMaterialLevel=9、USI_Hash=16、Threads=1または2を設定。
+各局面でbase→patch→patch→baseの順に`go movetime 1000`。
+各探索の最終infoのnodesを足した値を示す。CPU固定・周波数固定・専有はしていない。
+
+| Threads | base nodes（6探索合計） | patch nodes（6探索合計） | patch/base |
+|---|---:|---:|---:|
+| 1 | 3,864,926 | 3,747,142 | 0.9695 |
+| 2 | 7,374,983 | 7,079,358 | 0.9599 |
+
+この短いMaterial評価での比較では約3–4%のnodes減少を観測した。
+本番NNUE、長い持時間、多数スレッド、棋力の採否を示す測定ではない。
+固定時間SPRT等の正式な採否検定は実施していない。
+
+使用局面（USI position引数）:
+
+```text
+startpos
+startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e 8d8e 2e2d 2c2d
+sfen 8l/1l+R2P3/p2pBG1pp/kps1p4/Nn1P2G2/P1P1P2PP/1PS6/1KSG3+r1/LN2+p3L w Sbgn3p 124
+```
+
+別にThreads=1、同じ3局面を`go depth 5`で比較すると、nodesは順に2009 / 546 / 6189で一致し、
+score・PV・bestmoveも一致した。これは決定性回帰の確認で、速度・棋力の証拠には使わない。
+
+## 競合頻度の限定観測
+
+事前にkey1/2を同じclusterに保存し、2writer + 2readerがその2keyだけを10万回ずつprobeする
+独立harnessでは、400,000 probeのうち367,345（91.84%）が排他競合でmissした。
+writer側のprobe missは184,640で、これらはwriteも省略される。probe成功後のwrite時競合は
+別途数えておらず、書込み省略数は下限のみ。実探索の競合頻度は未計測。
+これは単一clusterに負荷を集中させた意図的な極端条件であり、通常のcache hit率を表さない。

--- a/docs/performance/20260909_tt_atomic_safety.md
+++ b/docs/performance/20260909_tt_atomic_safety.md
@@ -85,8 +85,9 @@ value/boundの対応は証明できず、別途一貫性検証またはTT値の�
   自動修正は実行できなかったが、上記の通常Clippyは警告ゼロ。
 - `cargo test`: CSA clientの `csa_entering_king_rule` 5件がTCP bindのEPERMで失敗。
   workspace全体のgateは未達で、TCP bindが許可された環境で再実行が必要。
-- `cargo test -p rshogi-core`: unit 1,051件、通常doctest 40件、
-  drop/resizeのcompile-fail doctest 2件が通過（計16件ignored）。
+- `cargo test -p rshogi-core`: unit 1,051件が通過。
+  doctestはdrop/resizeのcompile-fail 2件のみで、いずれも通過。
+  同時に走る40件は `tests/build_rs_checks.rs` のintegration testであり、doctestではない。
 - `tt-trace,search-stats` 有効のcore全対象ClippyとTTテスト20件: 通過。
 - build-std付きThreadSanitizer: TTテスト20件通過。コマンドは後掲と同じ。
 - `bash scripts/check-tracked-abs-paths.sh` / `git diff --check`: 通過。
@@ -142,7 +143,7 @@ uptime
 ./target/release/search_only_ab \
   --baseline /path/to/base/engines/rshogi-usi-layerstacks-halfka_hm_merged-1536x16x32-none \
   --candidate ./engines/rshogi-usi-layerstacks-halfka_hm_merged-1536x16x32-none \
-  --positions /path/to/positions.txt --movetime-ms 3000 --pattern abba --rounds 2 \
+  --positions /path/to/positions.txt --movetime-ms 3000 --pattern abba --rounds 3 \
   --threads 1 --hash-mb 16 --cpu 2 \
   --eval-file "$SHOGI_DATA/nnue/20260713-wrm-n2s1200-1536x16x32/ls-1536x16x32-halfka-hm-merged-wrm-n2s1200-400.bin" \
   --usi-option LS_BUCKET_MODE=kingrank9


### PR DESCRIPTION
共有 TT の Rust UB (共有参照から生ポインタを作り、複数スレッドから非 atomic に読み書き) を
除去します。payload を 1 本の `AtomicU64`、短縮キーを別配列に置く SoA へ組み替え、排他は
取らずに読み書きします。異なる書込みが混ざったエントリは短縮キーの照合と TT move の
合法性検査で弾きます。

`ProbeResult` はテーブル借用に結び付いた cluster 参照と slot を保持し、生ポインタ経由の
可変参照を除去します。drop / resize 後に write を呼ぶ順序は型検査で拒否されます (compile-fail
doctest 2 件)。

`Cluster` は 32 バイトを維持するため、**同じ Hash 設定での TT 容量は base と変わりません**
(`cluster_count = mb_size * 1024 * 1024 / size_of::<Cluster>()`)。1 エントリあたりの atomic
アクセスは 2 回 (payload + 短縮キー) です。

## Stockfish との関係

Stockfish も TT の racy な更新を許容しており、`TTEntry` の各フィールドを `RelaxedAtomic` で
持ちます (`src/tt.cpp`)。本 PR は同じ方針で、payload 内のフィールド対応が不可分な分だけ
混在の種類が少なくなります。

**残存リスク**: 短縮キーと payload は別ワードなので、同一 slot への並行書込みが交錯すると
「別局面の payload を短縮キー照合が通してしまう」ケースは残ります。これを完全に消すには
`key ^ data` のチェックサム方式が必要ですが、エントリが 16 バイトになり `Cluster` 48 バイト
= **TT 容量 33% 減**となるため採用していません。Stockfish が容認しているのと同じクラスの
リスクです。

## 速度

固定ノード (`--nodes 200000`)、hash 256MB、production net (gated50b-1200) で、base との
直接対決 (同一対局集合を先後入替) を測った。固定ノードなので両者は同じ仕事をする。

sh11235-ws-win (Zen5, 他プロセスなし):

| 条件 | base 比 |
|---|---|
| 並列度 2 | +1.01% 遅い |
| 並列度 24 | +1.10% 遅い |
| SPRT run 1 の avg_nps (byoyomi 1000, 並列度 24, 35,500 手) | -1.05% |

**本 PR は約 1% 遅い。** 棋力への影響は SPRT で確認した (下記、accept_h1)。

フィールドごとに relaxed atomic を持つ 10 バイト連続レイアウト (Stockfish と同一構造) も
実装して比較したが、1 エントリで `AtomicU16` を 5 回触るため更に遅く、採用しなかった。

初版で報告していた「1T 0.9695 / 2T 0.9599」は撤去済みのクラスタ排他方式の数値。

## 探索の同一性

1 スレッドでは TT に並行 writer が存在しないため、base と本 PR の探索は一致します。
固定ノードで実測し、`nodes` / `score` / `PV` / `bestmove` が完全一致することを確認しました
(production net、4 局面、`avg_nodes=186094` 一致)。

## 棋力 (SPRT)

固定時間では速度差が指し手に影響するため、非退行を SPRT で確認しています。

| run | seed | TC / 並列度 | pairs | nelo (test 視点) | 判定 |
|---|---|---|---|---|---|
| 1 | 20260910 | byoyomi 1000 / 24 | 2,641 | -9.63 ± 9.37 | 打ち切り (境界未到達、採否に用いない) |
| 2 | 20260911 | byoyomi 500 / 16 | 1,372 | +8.67 ± 13.01 | **accept_h1** (LLR +3.105) |

run 1 は計測条件の妥当性に疑いが生じたため owner 判断で drain 停止しました (境界未到達)。
独立 seed の run 2 は符号が反転して `accept_h1` に到達し、**-10 nElo 以上の退行がない**ことが
確定しました。run 2 も Error pairs 0 / Retried 0 / Exhausted 0 / Invalid false です。

なお run 1 の -9.6 nElo は機序と整合しません。倍のノードで +50〜70 Elo という経験則では
-9.6 nElo に約 10% の速度差が必要ですが、実測は ±1% です。

bounds は `H0 = -10 nElo / H1 = 0 nElo`、α=β=0.05。詳細と事前登録は
[rshogi-notes の実験 doc](https://github.com/SH11235/rshogi-notes/blob/main/experiments/rshogi/20260910-tt-lockless-soa-sprt.md)。

## 統計・トレースの計上

競合で書込みを省略しても成功として計上していた不具合を併せて修正しています。`write` が
格納実施の成否を返し、探索側 7 箇所は成功時のみ `tt-trace` の `kind=write` と
`search-stats` の `tt_write_by_depth` を記録します。戻り値を捨てて無条件計上へ戻す形状は
`#[must_use]` で CI (`clippy -D warnings`) が弾きます。

## 検証

- cargo fmt / cargo clippy --workspace --all-targets -- -D warnings / cargo test --workspace: 通過
- ThreadSanitizer (build-std) で TT テスト 20 件通過
- drop / resize 後の write を拒否する compile-fail doctest 2 件通過
- 固定ノードでの base との探索一致 (production net、4 局面)
- 速度計測 (上記、2 環境 / 同一トーナメント / 固定ノード)
- SPRT run 1 は Error pairs 0 / Retried 0 / Exhausted 0 / Invalid false
- 独立 Codex レビュー: 排他撤去後の記述不整合と検証 doc の件数誤りを指摘され修正済み

方法・数値・残存リスクは `docs/performance/20260909_tt_atomic_safety.md` に記録しています。
