### PR TITLE
fix(csa): 全履歴で千日手と連続王手を裁定する

### DIFF
--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1683,16 +1683,18 @@ fn oute_sennichite_from_initial_sfen_ends_as_perpetual_check_loss_e2e() {
         let _ = read_line_raw(&mut rb).await.unwrap();
         let _ = read_line_raw(&mut rw).await.unwrap();
 
-        send_line(&mut ww, "-3242OU").await;
-        let _ = read_until(&mut rb, "-3242OU,T0").await;
-        let _ = read_until(&mut rw, "-3242OU,T0").await;
-        send_line(&mut wb, "+3848HI").await;
-        let _ = read_until(&mut rb, "+3848HI,T0").await;
-        let _ = read_until(&mut rw, "+3848HI,T0").await;
-        send_line(&mut ww, "-4232OU").await;
-        let _ = read_until(&mut rb, "-4232OU,T0").await;
-        let _ = read_until(&mut rw, "-4232OU,T0").await;
-        send_line(&mut wb, "+4838HI").await;
+        for ply in 0..12 {
+            let tok = ["-3242OU", "+3848HI", "-4232OU", "+4838HI"][ply % 4];
+            if tok.starts_with('+') {
+                send_line(&mut wb, tok).await;
+            } else {
+                send_line(&mut ww, tok).await;
+            }
+            if ply < 11 {
+                assert_eq!(read_line_raw(&mut rb).await.unwrap(), format!("{tok},T0"));
+                assert_eq!(read_line_raw(&mut rw).await.unwrap(), format!("{tok},T0"));
+            }
+        }
 
         let black_end = read_until(&mut rb, "#LOSE").await;
         let white_end = read_until(&mut rw, "#WIN").await;

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -434,6 +434,113 @@ mod tests {
     }
 
     #[test]
+    fn replay_preserves_full_repetition_history_and_terminal_broadcasts() {
+        let long_cycle = [
+            "+5949OU", "-5141OU", "+4939OU", "-4131OU", "+3938OU", "-3132OU", "+3837OU", "-3233OU",
+            "+3747OU", "-3343OU", "+4757OU", "-4353OU", "+5767OU", "-5363OU", "+6768OU", "-6362OU",
+            "+6869OU", "-6261OU", "+6959OU", "-6151OU",
+        ];
+        for (sfen, cycle, code) in [
+            ("4k4/9/9/9/9/9/9/9/4K4 b Pp 1", long_cycle.as_slice(), "#SENNICHITE"),
+            (
+                "9/6k2/9/9/9/9/9/6R2/K8 w - 1",
+                ["-3242OU", "+3848HI", "-4232OU", "+4838HI"].as_slice(),
+                "#OUTE_SENNICHITE",
+            ),
+            (
+                "9/5k3/9/9/9/9/9/6R2/K8 b - 1",
+                ["+3848HI", "-4232OU", "+4838HI", "-3242OU"].as_slice(),
+                "#OUTE_SENNICHITE",
+            ),
+        ] {
+            let mut cfg = baseline_config();
+            cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
+            cfg.initial_sfen = Some(sfen.to_owned());
+            let cfg: PersistedConfig =
+                serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+            let rows: Vec<_> = cycle
+                .iter()
+                .cycle()
+                .take(cycle.len() * 3)
+                .enumerate()
+                .map(|(ply, line)| {
+                    move_row(
+                        ply as i64 + 1,
+                        if line.starts_with('+') {
+                            "black"
+                        } else {
+                            "white"
+                        },
+                        line,
+                        0,
+                    )
+                })
+                .collect();
+            let rows: Vec<MoveRow> =
+                serde_json::from_str(&serde_json::to_string(&rows).unwrap()).unwrap();
+            let mut uninterrupted = directly_played(&cfg, &[]);
+            let split = rows.len() - 1;
+            for row in &rows[..split] {
+                let side = if row.color == "black" {
+                    Color::Black
+                } else {
+                    Color::White
+                };
+                let result = uninterrupted
+                    .handle_line(side, &CsaLine::new(&row.line), PLAY_STARTED_AT_MS)
+                    .unwrap();
+                assert!(matches!(result.outcome, HandleOutcome::MoveAccepted { .. }));
+            }
+            let ReplaySummary::Restored { mut core } = replay_core_room(&cfg, &rows[..split])
+            else {
+                panic!("restore failed");
+            };
+            let last = &rows[split];
+            let side = if last.color == "black" {
+                Color::Black
+            } else {
+                Color::White
+            };
+            let expected = uninterrupted
+                .handle_line(side, &CsaLine::new(&last.line), PLAY_STARTED_AT_MS)
+                .unwrap();
+            let actual =
+                core.handle_line(side, &CsaLine::new(&last.line), PLAY_STARTED_AT_MS).unwrap();
+            assert_eq!(actual.outcome, expected.outcome);
+            if code == "#SENNICHITE" {
+                assert!(matches!(actual.outcome, HandleOutcome::GameEnded(GameResult::Sennichite)));
+                assert!(actual.broadcasts.iter().any(|b| b.line.as_str() == "#DRAW"));
+            } else {
+                assert!(matches!(
+                    actual.outcome,
+                    HandleOutcome::GameEnded(GameResult::OuteSennichite {
+                        loser: Color::Black
+                    })
+                ));
+                assert!(actual.broadcasts.iter().any(|b| b.line.as_str() == "#LOSE"));
+                assert!(actual.broadcasts.iter().any(|b| b.line.as_str() == "#WIN"));
+            }
+            assert!(actual.broadcasts.iter().any(|b| b.line.as_str() == code));
+            assert!(actual.broadcasts.iter().any(
+                |b| b.ply == Some(rows.len() as u32) && b.line.as_str().starts_with(&last.line)
+            ));
+            let messages = |result: &rshogi_csa_server::game::room::HandleResult| {
+                result
+                    .broadcasts
+                    .iter()
+                    .map(|b| (b.target, b.line.as_str().to_owned(), b.ply))
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(messages(&actual), messages(&expected));
+            let ReplaySummary::Restored { core: finished } = replay_core_room(&cfg, &rows) else {
+                panic!("terminal move restore failed");
+            };
+            assert_eq!(finished.status(), core.status());
+            assert_eq!(finished.moves_played(), rows.len() as u32);
+        }
+    }
+
+    #[test]
     fn replay_without_play_started_returns_agree_waiting_room() {
         let cfg = baseline_config();
         let summary = replay_core_room(&cfg, &[]);

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -615,7 +615,7 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteLose => {
-                // `OuteSennichiteLose` ⇔ `Position::repetition_state` の `Lose` で、
+                // 対局全履歴の4回目に `OuteSennichiteLose` と判定されたとき、
                 // 「手番側 (= side-to-move after the last move = from.opposite()) が
                 // 連続王手していた側で反則負け」を意味する。循環の最終手 (from) が
                 // 非王手 (=受け手の escape) で閉じ、from.opposite() がサイクル中ずっと
@@ -630,7 +630,7 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteWin => {
-                // `OuteSennichiteWin` ⇔ `Position::repetition_state` の `Win` で、
+                // 対局全履歴の4回目に `OuteSennichiteWin` と判定されたとき、
                 // 「手番側 (from.opposite()) が勝ち」= 直前に指した from が連続王手
                 // していた側で反則負け。循環の最終手が from による王手で閉じた場合に発火。
                 let mut result = self.finish(GameResult::OuteSennichite { loser: from });
@@ -1456,7 +1456,7 @@ mod tests {
     fn oute_sennichite_win_variant_loses_the_last_checker() {
         // Win variant: 開始 SFEN で白が既に黒飛の王手下にある (side=W)。
         // 4 手 1 サイクル (白退避 → 黒再王手 → 白退避 → 黒再王手) で開始 SFEN に復帰。
-        // 連続王手は反則行為なので 1 サイクルで反則確定 (競技将棋ルール準拠)。
+        // 3 サイクル後の同一局面4回目で反則確定。
         // 循環最終手 (+4838HI) は黒の王手手なので from=Black、連続王手側の黒が敗者。
         let mut room = room_with_sfen(EnteringKingRule::Point24, "9/6k2/9/9/9/9/9/6R2/K8 w - 1");
         agree_both(&mut room);
@@ -1465,6 +1465,12 @@ mod tests {
             (Color::Black, "+3848HI"),
             (Color::White, "-4232OU"),
         ];
+        for _ in 0..2 {
+            for (c, tok) in prefix.iter().chain(std::iter::once(&(Color::Black, "+4838HI"))) {
+                let r = room.handle_line(*c, &line(tok), 0).unwrap();
+                assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+            }
+        }
         for (c, tok) in &prefix {
             let r = room.handle_line(*c, &line(tok), 0).unwrap();
             assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
@@ -1493,6 +1499,12 @@ mod tests {
             (Color::White, "-4232OU"),
             (Color::Black, "+4838HI"),
         ];
+        for _ in 0..2 {
+            for (c, tok) in prefix.iter().chain(std::iter::once(&(Color::White, "-3242OU"))) {
+                let r = room.handle_line(*c, &line(tok), 0).unwrap();
+                assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+            }
+        }
         for (c, tok) in &prefix {
             let r = room.handle_line(*c, &line(tok), 0).unwrap();
             assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));

--- a/crates/rshogi-csa-server/src/game/validator.rs
+++ b/crates/rshogi-csa-server/src/game/validator.rs
@@ -8,7 +8,7 @@
 use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::position::Position;
 use rshogi_core::types::{
-    Color as CoreColor, EnteringKingRule, File, Move, PieceType, Rank, RepetitionState, Square,
+    Color as CoreColor, EnteringKingRule, File, Move, PieceType, Rank, Square,
 };
 
 use crate::types::{Color, CsaMoveToken};
@@ -124,34 +124,57 @@ impl Validator {
         Err(Violation::Illegal)
     }
 
-    /// 千日手判定。`pos` は最後の `do_move` 直後の局面を渡す。
+    /// 対局履歴全体の同一局面4回目を判定する。`pos` は合法手適用後の局面。
     ///
-    /// `Position::repetition_state` 内部で連続王手判定も行われるため、
-    /// 千日手成立時の勝敗側もここで切り分ける。
-    ///
-    /// **発火タイミング:**
-    /// - 通常千日手 (Draw): 同一局面 4 回目の到達で発火する。`state.repetition < 0`
-    ///   (= `times >= 3` = 4 回目以降の出現) を必須条件としており、それ以前の非決定的
-    ///   な再来では `None` を返す。これは競技将棋の「同一局面 4 回で引き分け」ルール
-    ///   に一致する。
-    /// - 連続王手千日手 (Win/Lose): 1 サイクル目の再来で発火する。連続王手は
-    ///   反則行為であり、1 循環で反則確定すればそれ以降は続行する意味がないため、
-    ///   非決定的な (`rep > 0` の) 再来でも Verdict を返す。
+    /// 盤面・双方の持駒・手番が一致する直近4回の区間で、一方の全着手が王手なら
+    /// その側が負けとなる。探索用の16手窓や `state.repetition` は使用しない。
+    /// SFENだけを再設定すると履歴は失われるため、復元時は開始局面から指し手を再生する。
     pub fn classify_repetition(&self, pos: &Position) -> RepetitionVerdict {
-        let state = pos.state();
-        if state.repetition == 0 {
-            return RepetitionVerdict::None;
-        }
-        match state.repetition_type {
-            RepetitionState::None | RepetitionState::Superior | RepetitionState::Inferior => {
-                RepetitionVerdict::None
+        let current = pos.state();
+        let mut index = pos.state_index();
+        let mut occurrences = 1;
+        let mut rewind: Option<Position> = None;
+        let max_back = current.plies_from_null.max(0) as usize;
+        for distance in 1..=max_back {
+            let Some(previous) = pos.state_at(index).previous_index() else {
+                break;
+            };
+            index = previous;
+            let state = pos.state_at(index);
+            if distance % 2 != 0
+                || state.board_key != current.board_key
+                || state.hand_key != current.hand_key
+            {
+                continue;
             }
-            // 非決定的な再来 (rep > 0) では発火せず対局続行。決定的 (rep < 0) でのみ発火。
-            RepetitionState::Draw if state.repetition < 0 => RepetitionVerdict::Sennichite,
-            RepetitionState::Draw => RepetitionVerdict::None,
-            RepetitionState::Lose => RepetitionVerdict::OuteSennichiteLose,
-            RepetitionState::Win => RepetitionVerdict::OuteSennichiteWin,
+            // ハッシュは候補抽出だけに使い、衝突時も盤面と持駒を実際に比較する。
+            // clone/undoは一致候補があるときだけ行い、元の対局履歴は変更しない。
+            let past = rewind.get_or_insert_with(|| pos.clone());
+            while past.state_index() != index {
+                let mv = past.state().last_move;
+                past.undo_move(mv);
+            }
+            if past.side_to_move() != pos.side_to_move()
+                || [CoreColor::Black, CoreColor::White]
+                    .iter()
+                    .any(|&c| past.hand(c) != pos.hand(c))
+                || Square::all().any(|sq| past.piece_on(sq) != pos.piece_on(sq))
+            {
+                continue;
+            }
+            occurrences += 1;
+            if occurrences == 4 {
+                let side = pos.side_to_move();
+                return if current.continuous_check[side.index()] >= distance as i32 {
+                    RepetitionVerdict::OuteSennichiteLose
+                } else if current.continuous_check[(!side).index()] >= distance as i32 {
+                    RepetitionVerdict::OuteSennichiteWin
+                } else {
+                    RepetitionVerdict::Sennichite
+                };
+            }
         }
+        RepetitionVerdict::None
     }
 
     /// 通常の千日手（4 回出現の引き分け）が成立しているか。
@@ -770,6 +793,62 @@ mod tests {
     }
 
     #[test]
+    fn full_history_repetition_at_60_ply_includes_starting_hands() {
+        for hands in ["-", "Pp"] {
+            let mut pos = pos_from_sfen(&format!("4k4/9/9/9/9/9/9/9/4K4 b {hands} 1"));
+            let v = Validator::new(EnteringKingRule::Point24);
+            let cycle = [
+                "5i4i", "5a4a", "4i3i", "4a3a", "3i3h", "3a3b", "3h3g", "3b3c", "3g4g", "3c4c",
+                "4g5g", "4c5c", "5g6g", "5c6c", "6g6h", "6c6b", "6h6i", "6b6a", "6i5i", "6a5a",
+            ];
+            for ply in 0..60 {
+                let mv = pos.to_move(Move::from_usi(cycle[ply % 20]).unwrap()).unwrap();
+                let mut legal = MoveList::new();
+                generate_legal_all(&pos, &mut legal);
+                assert!(legal.iter().any(|&candidate| candidate == mv));
+                pos.do_move(mv, pos.gives_check(mv));
+                let expected = if ply == 59 {
+                    RepetitionVerdict::Sennichite
+                } else {
+                    RepetitionVerdict::None
+                };
+                assert_eq!(v.classify_repetition(&pos), expected, "ply {}", ply + 1);
+            }
+            assert_eq!(pos.state().repetition, 0, "search window remains unchanged");
+        }
+    }
+
+    #[test]
+    fn interrupted_checking_interval_is_draw_at_fourth_occurrence() {
+        let mut pos = pos_from_sfen("9/6k2/9/9/9/9/9/6R2/K8 w - 1");
+        let v = Validator::new(EnteringKingRule::Point24);
+        let checking = ["-3242OU", "+3848HI", "-4232OU", "+4838HI"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &checking);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::None);
+        let detour = [
+            "-3242OU", "+9989OU", "-4252OU", "+8999OU", "-5242OU", "+3848HI", "-4232OU", "+4838HI",
+        ];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &detour);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::None);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &checking);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::Sennichite);
+    }
+
+    #[test]
+    fn hash_collision_does_not_replace_exact_board_comparison() {
+        let mut pos = pos_from_sfen(rshogi_core::position::SFEN_HIRATE);
+        let v = Validator::new(EnteringKingRule::Point24);
+        let initial_key = pos.state().board_key;
+        let cycle = ["+4948KI", "-4142KI", "+4849KI", "-4241KI"];
+        for _ in 0..2 {
+            apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        }
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle[..2]);
+        pos.state_mut().board_key = initial_key;
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::None);
+    }
+
+    #[test]
     fn classify_repetition_returns_sennichite_after_12_ply_gold_dance() {
         // 平手初期局面から両者の左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて
         // 3 サイクル (= 12 手) で初期局面 4 回目の到達 → 通常千日手。
@@ -798,8 +877,10 @@ mod tests {
         let mut pos = pos_from_sfen("9/6k2/9/9/9/9/9/6R2/K8 w - 1");
         let v = Validator::new(EnteringKingRule::Point24);
         let cycle = ["-3242OU", "+3848HI", "-4232OU", "+4838HI"];
-        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
-        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        for _ in 0..2 {
+            apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+            assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::None);
+        }
         apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
         assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteWin);
         // `is_oute_sennichite` は勝敗を区別しない薄いラッパなので両 variant で true。
@@ -819,8 +900,10 @@ mod tests {
         let mut pos = pos_from_sfen("9/5k3/9/9/9/9/9/6R2/K8 b - 1");
         let v = Validator::new(EnteringKingRule::Point24);
         let cycle = ["+3848HI", "-4232OU", "+4838HI", "-3242OU"];
-        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
-        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        for _ in 0..2 {
+            apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+            assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::None);
+        }
         apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
         assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteLose);
     }

--- a/docs/csa-server/protocol-reference.md
+++ b/docs/csa-server/protocol-reference.md
@@ -203,6 +203,15 @@ CSA v1.2.1 標準 `BEGIN Game_Summary` / `END Game_Summary` の組み立ては
 
 ## 8. 終局メッセージ
 
+千日手は開始局面を含む全対局履歴で、盤面・双方の持駒・手番が同じ局面の4回目に
+裁定する。周期が16手を超える場合も対象。4回の出現を跨ぐ全区間で一方の着手が
+すべて王手なら王手側の反則負けとし、1/2循環目では終局しない。途中で王手が途切れた
+場合は通常千日手となる。成立条件は[日本将棋連盟の対局規則 第8条・第10条第10項](https://www.shogi.or.jp/match/taikyoku_rules/)に合わせる。
+
+本サーバーは通常千日手を指し直しではなく既存仕様の `#DRAW` で終了する。
+cold startでは開始SFENと全指し手の再生で履歴を復元するため、最終SFENだけの復元では
+同じ裁定にならない。過去の「連続王手1循環で終局」および「探索用16手窓の流用」は使用しない。
+
 [`crates/rshogi-csa-server/src/game/result.rs`](../../crates/rshogi-csa-server/src/game/result.rs) で生成。送信順は **「(a) 終局理由コード →
 (b) 勝敗コード」** を厳守する。マッピングは `result.rs::GameResult::server_messages`
 で定義:


### PR DESCRIPTION
CSA対局の千日手を開始局面からの全履歴で判定し、20手周期のような探索用16手窓より長い反復も4回目に終了させます。連続王手も1循環で終了させず、同一局面4回を跨ぐ全区間で一方の着手がすべて王手だった場合にその側の負けとします。

盤面・手番・双方持駒のハッシュ一致は候補抽出に使い、候補がある場合だけ局面を複製してundoし、実盤と持駒も照合します。探索用の反復判定は変更していません。既存の開始SFEN＋指し手列の再生でcold start後も同じ判定になるため、新しい永続データ形式は不要です。

成立条件は[日本将棋連盟の対局規則 第8条・第10条第10項](https://www.shogi.or.jp/match/taikyoku_rules/)に合わせます。通常千日手の終了通知は本サーバー既存の `#DRAW` を維持します。仕様と復元時の履歴要件をprotocol-referenceに追記しました。

検証:
- 20手周期60手でDraw、59手までは続行（初期持駒あり/なし）
- 連続王手1/2循環では続行、3循環目でWin/Lose双方の正しい敗者
- 途中王手が途切れた4回目はDraw、ハッシュ衝突時の実盤照合
- config/movesの保存形式roundtrip、最終手直前の復元、最終手/理由/勝敗の配信一致、終局手込みの再生
- cargo fmt / required clippy / workspace all-targets clippy -D warnings / cargo test / tracked絶対パス検査
- TCP接続で11手まで両側に指し手echo、12手目に王手側LOSE/相手WIN
- 独立Codexレビュー2件（双方APPROVE）

根拠: [01-position T2 / POS-05・06](https://github.com/SH11235/rshogi-notes/blob/7c48a0dd2ec5f3f4201698de23290e457b7f7509/rshogi/20260909-code-review-01-position-bec3b988-031813/tasks.md)。過去の実対局における該当件数・レーティングへの影響量は未測定です。