### PR TITLE
fix(search): 合法手なしでもponderとinfiniteの終了通知を待つ

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1436,23 +1436,13 @@ where
             eprintln!("info string declaration win: {}", decl_move.to_usi());
         }
 
-        // ponder/infinite 待機: bestmove を早出ししない（USI仕様準拠）
-        if let Some(ref ms) = main_state {
-            while !worker.state.abort
-                && !time_manager.stop_requested()
-                && (time_manager.is_pondering() || limits.infinite)
-            {
-                if ms.ponderhit_flag.swap(false, Ordering::Relaxed) {
-                    time_manager.on_ponderhit();
-                }
-                thread::sleep(Duration::from_millis(1));
-            }
-        }
+        wait_for_search_release(worker.state.abort, limits, time_manager, main_state.as_deref());
         return 0;
     }
 
     if worker.state.root_moves.is_empty() {
         worker.state.best_move = Move::NONE;
+        wait_for_search_release(worker.state.abort, limits, time_manager, main_state.as_deref());
         return 0;
     }
 
@@ -1846,20 +1836,8 @@ where
         }
     }
 
-    // ponder中 / go infinite中はGUIからstop/ponderhitが来るまでbestmoveを出力してはならない（YaneuraOu準拠）
-    // 反復深化ループが自然に終了した場合（MAX_PLY到達や詰み確定）でもここで待機する
-    if let Some(ref ms) = main_state {
-        while !worker.state.abort
-            && !time_manager.stop_requested()
-            && (time_manager.is_pondering() || limits.infinite)
-        {
-            if ms.ponderhit_flag.swap(false, Ordering::Relaxed) {
-                time_manager.on_ponderhit();
-            }
-            // YaneuraOu 同様、探索終了後の待機では短時間 sleep して busy wait を避ける。
-            thread::sleep(Duration::from_millis(1));
-        }
-    }
+    // 反復深化が自然終了した場合も、終局分岐と同じ通知待機を通る。
+    wait_for_search_release(worker.state.abort, limits, time_manager, main_state.as_deref());
 
     // 中断した探索で信頼できないPVになった場合のフォールバック
     if worker.state.abort
@@ -1880,6 +1858,25 @@ where
     effective_multi_pv
 }
 
+/// mainだけが終了通知を待つ。helperは待たずに呼出側へ戻る。
+fn wait_for_search_release(
+    aborted: bool,
+    limits: &LimitsType,
+    time_manager: &mut TimeManagement,
+    main_state: Option<&MainThreadState<'_>>,
+) {
+    if let Some(ms) = main_state {
+        while !aborted
+            && !time_manager.stop_requested()
+            && (time_manager.is_pondering() || limits.infinite)
+        {
+            if ms.ponderhit_flag.swap(false, Ordering::Relaxed) {
+                time_manager.on_ponderhit();
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+}
 fn root_score_is_initialized(score: Value) -> bool {
     let raw = score.raw();
     -Value::INFINITE.raw() < raw && raw < Value::INFINITE.raw()
@@ -2011,6 +2008,91 @@ mod tests {
     /// SearchWorkerは大きなスタック領域を使うため、テストは別スレッドで実行
     const STACK_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
+    #[test]
+    fn terminal_roots_wait_after_initialization() {
+        use std::sync::mpsc;
+        let mate = "4k4/9/9/9/9/9/4r4/4g4/4K4 b - 1";
+        let declaration = "KGG6/SS7/PPPPPP3/9/9/9/2pppppp1/1ss1gg1nl/4k2nl b 2R2B3p 1";
+        for (sfen, expected) in [(mate, Move::NONE), (declaration, Move::WIN)] {
+            for mode in 0..4 {
+                let (ready_tx, ready_rx) = mpsc::channel();
+                let (done_tx, done_rx) = mpsc::channel();
+                let thread = std::thread::Builder::new()
+                    .stack_size(STACK_SIZE)
+                    .spawn(move || {
+                        let mut search = Search::new_with_eval_hash(1, 1);
+                        let mut pos = Position::new();
+                        pos.set_sfen(sfen).unwrap();
+                        if expected == Move::NONE {
+                            assert!(pos.in_check());
+                            assert!(
+                                super::super::RootMoves::from_legal_moves(&pos, &[]).is_empty()
+                            );
+                        }
+                        let mut limits = LimitsType::new();
+                        limits.ponder = mode == 1 || mode == 2;
+                        limits.infinite = mode == 3;
+                        limits.set_start_time();
+                        search.start_time = limits.start_time;
+                        let mut tm = TimeManagement::new(
+                            Arc::clone(&search.stop),
+                            Arc::clone(&search.ponderhit_flag),
+                        );
+                        tm.init(&limits, pos.side_to_move(), pos.game_ply(), 256);
+                        let mut worker = SearchWorker::new(
+                            Arc::clone(&search.tt),
+                            Arc::clone(&search.eval_hash),
+                            256,
+                            0,
+                            SearchTuneParams::default(),
+                        );
+                        worker.entering_king_rule = EnteringKingRule::Point27;
+                        worker.prepare_search(&limits);
+                        search.worker = Some(worker);
+                        // F01のinit resetより後に同期し、通知消失と終局待機を分離する。
+                        ready_tx
+                            .send((Arc::clone(&search.stop), Arc::clone(&search.ponderhit_flag)))
+                            .unwrap();
+                        search.search_with_callback(
+                            &mut pos,
+                            &limits,
+                            &mut tm,
+                            1,
+                            |_info: &SearchInfo| {},
+                            false,
+                        );
+                        done_tx.send(search.worker.as_ref().unwrap().state.best_move).unwrap();
+                    })
+                    .unwrap();
+                let (stop, hit) = ready_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                if mode != 0 {
+                    assert!(matches!(
+                        done_rx.recv_timeout(Duration::from_millis(100)),
+                        Err(mpsc::RecvTimeoutError::Timeout)
+                    ));
+                    if mode == 1 {
+                        hit.store(true, Ordering::Relaxed);
+                    } else {
+                        if mode == 3 {
+                            hit.store(true, Ordering::Relaxed);
+                            assert!(
+                                matches!(
+                                    done_rx.recv_timeout(Duration::from_millis(50)),
+                                    Err(mpsc::RecvTimeoutError::Timeout)
+                                ),
+                                "infiniteはhitだけで終了しない"
+                            );
+                        }
+                        stop.store(true, Ordering::Relaxed);
+                    }
+                }
+                let result = done_rx.recv_timeout(Duration::from_secs(2));
+                stop.store(true, Ordering::Relaxed);
+                thread.join().unwrap();
+                assert_eq!(result.unwrap(), expected, "mode={mode}");
+            }
+        }
+    }
     #[test]
     fn test_aggregate_best_move_changes_empty() {
         let (sum, threads) = aggregate_best_move_changes(&[]);

--- a/crates/rshogi-usi/tests/usi_flow.rs
+++ b/crates/rshogi-usi/tests/usi_flow.rs
@@ -25,6 +25,86 @@ fn stop_then_quit_outputs_bestmove() {
     assert!(output.status.success());
 }
 
+/// 終局でもponder/infiniteは明示stopまでbestmoveを保留する。
+#[test]
+fn terminal_positions_obey_usi_output_wait() {
+    use std::io::{BufRead, BufReader};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+    for (sfen, expected) in [
+        ("4k4/9/9/9/9/9/4r4/4g4/4K4 b - 1", "resign"),
+        ("KGG6/SS7/PPPPPP3/9/9/9/2pppppp1/1ss1gg1nl/4k2nl b 2R2B3p 1", "win"),
+    ] {
+        for mode in ["depth 1", "ponder depth 1", "infinite"] {
+            let mut child = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"))
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn engine");
+            let (sender, receiver) = mpsc::channel();
+            let stdout = child.stdout.take().unwrap();
+            let reader = std::thread::spawn(move || {
+                for line in BufReader::new(stdout).lines() {
+                    if sender.send(line.expect("read stdout")).is_err() {
+                        break;
+                    }
+                }
+            });
+            write!(child.stdin.as_mut().unwrap(), "{USI_INIT}").unwrap();
+            let result = (|| -> Result<String, String> {
+                let deadline = Instant::now() + Duration::from_secs(10);
+                loop {
+                    let line = receiver
+                        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                        .map_err(|err| err.to_string())?;
+                    if line == "readyok" {
+                        break;
+                    }
+                }
+                writeln!(child.stdin.as_mut().unwrap(), "position sfen {sfen}\ngo {mode}")
+                    .map_err(|err| err.to_string())?;
+                if mode != "depth 1" {
+                    let deadline = Instant::now() + Duration::from_millis(300);
+                    loop {
+                        match receiver
+                            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                        {
+                            Ok(line) if line.starts_with("bestmove ") => {
+                                return Err(format!("early {line}"));
+                            }
+                            Ok(_) => {}
+                            Err(mpsc::RecvTimeoutError::Timeout) => break,
+                            Err(err) => return Err(err.to_string()),
+                        }
+                    }
+                    // stopはinitで消されないためF01のponderhit競合を混ぜない。
+                    writeln!(child.stdin.as_mut().unwrap(), "stop")
+                        .map_err(|err| err.to_string())?;
+                }
+                let deadline = Instant::now() + Duration::from_secs(3);
+                loop {
+                    let line = receiver
+                        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                        .map_err(|err| err.to_string())?;
+                    if line.starts_with("bestmove ") {
+                        return Ok(line);
+                    }
+                }
+            })();
+            if result.is_ok() {
+                writeln!(child.stdin.as_mut().unwrap(), "quit").unwrap();
+            } else {
+                let _ = child.kill();
+            }
+            let status = child.wait().unwrap();
+            reader.join().unwrap();
+            let bestmove = result.unwrap_or_else(|err| panic!("{expected} {mode}: {err}"));
+            assert_eq!(bestmove.split_whitespace().nth(1), Some(expected));
+            assert!(status.success());
+        }
+    }
+}
+
 /// `go`→`gameover`→`quit` で探索を停止しつつ bestmove を返すこと
 #[test]
 fn gameover_outputs_bestmove() {


### PR DESCRIPTION
合法手がないrootで `go ponder` / `go infinite` が通知を待たずに `bestmove resign` を返す問題を修正します。宣言勝ちと反復深化の自然終了にあった待機を共通化し、合法手なしの分岐からも通します。

通常goは従来どおり即時にresignを返します。通常ponderはponderhitまたはstop、infiniteはstopまで待ちます。宣言勝ちのwin出力も同じ待機を使います。helperは待たずに戻り、既存のabort・stop・通知消費の条件を維持します。

検証:

- coreは詰み局面の王手とroot空を確認し、宣言勝ち局面と併せて通常/ponderhit/ponderstop/infiniteの8ケースで結果を検証
- TimeManagement::init後のchannel同期により、F01の初期化前通知消失を混ぜず待機を検証。infiniteはhitだけでは解除されないことも確認
- 実USIでは詰み/宣言勝ち×通常/ponder/infiniteの6ケースを検証。通常はstopなしでresign/win、ponder/infiniteは300msの出力保留後にstopで結果を取得
- 旧engineへ戻す反証ではponder時の早期bestmove resignで実USIテストが失敗
- cargo fmt、必須clippy、全workspace cargo test、全target clippy -D warnings、tracked絶対パス検査
- 独立Codexレビュー2件（双方APPROVE）

[03-cache-smp F05](https://github.com/SH11235/rshogi-notes/blob/181aaa14c73aa4bf11b1c907a946a20d0c288a1e/rshogi/20260909-code-review-03-cache-smp-bec3b988-codex-0330/tasks.md)への対応です。F01の通知reset競合、F02のponder時間管理は変更せず、main基点で他PRを含みません。接点のあるPR #1043・#1049・#1048とのファイル単位の3-way結合は競合なしです。過去の実対局での発生件数は未確認です。