### PR TITLE
fix(nnue): qa255の積和をCPU経路間で一致させる

### DIFF
--- a/crates/rshogi-core/src/nnue/activation.rs
+++ b/crates/rshogi-core/src/nnue/activation.rs
@@ -29,6 +29,10 @@ use super::constants::WEIGHT_SCALE_BITS;
 /// 各活性化関数は出力次元の変換比率（`OUTPUT_DIM_DIVISOR`）を定義し、
 /// L1層の入力次元を決定する。
 pub trait FtActivation: Clone + Copy + Default + Send + Sync + 'static {
+    /// FT 出力は qa <= 127 のとき、中間層出力は qa に関係なく 0..=127 に収まるか。
+    /// 独自実装は既定で全 u8 範囲の積和を使用する。
+    const SEVEN_BIT_WHEN_QA127: bool = false;
+
     /// 出力次元の除数
     ///
     /// L1層入力次元 = FT出力次元 * 2 / OUTPUT_DIM_DIVISOR
@@ -76,6 +80,8 @@ pub trait FtActivation: Clone + Copy + Default + Send + Sync + 'static {
 pub struct CReLU;
 
 impl FtActivation for CReLU {
+    const SEVEN_BIT_WHEN_QA127: bool = true;
+
     const OUTPUT_DIM_DIVISOR: usize = 1;
 
     #[inline]
@@ -385,6 +391,8 @@ fn crelu_i32_to_u8(input: &[i32], output: &mut [u8]) {
 pub struct PairwiseCReLU;
 
 impl FtActivation for PairwiseCReLU {
+    const SEVEN_BIT_WHEN_QA127: bool = true;
+
     const OUTPUT_DIM_DIVISOR: usize = 2;
 
     #[inline]
@@ -1101,6 +1109,8 @@ fn pairwise_crelu_i32_to_u8(input: &[i32], output: &mut [u8]) {
 pub struct SCReLU;
 
 impl FtActivation for SCReLU {
+    const SEVEN_BIT_WHEN_QA127: bool = true;
+
     const OUTPUT_DIM_DIVISOR: usize = 1;
 
     #[inline]

--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -788,15 +788,23 @@ mod tests {
         )
         .unwrap();
 
-        let mut pos = Position::new();
-        pos.set_sfen(SFEN_HIRATE).unwrap();
-        let mut dynamic_stack = DynamicHalfKxStack::new(&dynamic);
-        dynamic.refresh(&pos, &mut dynamic_stack);
-        let dynamic_value = dynamic.evaluate(&pos, &mut dynamic_stack);
+        for sfen in [
+            SFEN_HIRATE,
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2",
+            "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 3",
+        ] {
+            let mut pos = Position::new();
+            pos.set_sfen(sfen).unwrap();
+            // 各局面で双方を fresh に構築し、他局面の accumulator を流用しない。
+            let mut dynamic_stack = DynamicHalfKxStack::new(&dynamic);
+            dynamic.refresh(&pos, &mut dynamic_stack);
+            let dynamic_value = dynamic.evaluate(&pos, &mut dynamic_stack);
 
-        let mut static_stack = HalfKPStack::from_network(&static_net);
-        static_net.refresh_accumulator(&pos, &mut static_stack);
-        let static_value = static_net.evaluate(&pos, &static_stack);
-        assert_eq!(dynamic_value, static_value);
+            let mut static_stack = HalfKPStack::from_network(&static_net);
+            static_net.refresh_accumulator(&pos, &mut static_stack);
+            let static_value = static_net.evaluate(&pos, &static_stack);
+            assert_eq!(dynamic_value, static_value, "{sfen}");
+            println!("fresh HalfKP: {sfen}: {static_value:?}");
+        }
     }
 }

--- a/crates/rshogi-core/src/nnue/layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/layer_stacks.rs
@@ -121,7 +121,7 @@ impl<
         let mut output_arr = [0i32; 1];
 
         // L1: L1 → LS_L1_OUT
-        self.l1.propagate(input, &mut l1_out);
+        self.l1.propagate_7bit(input, &mut l1_out);
 
         // Split: [main_dim, 1]
         // l1_skip は最後の 1 要素、残り main_dim 要素を L2 入力へ変換する。
@@ -133,13 +133,13 @@ impl<
         l1_sqr_clipped_relu_activation::<LS_L1_OUT, LS_L2_IN>(&l1_out, &mut l2_input.0);
 
         // L2: LS_L2_IN → 32
-        self.l2.propagate(&l2_input.0, &mut l2_out);
+        self.l2.propagate_7bit(&l2_input.0, &mut l2_out);
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         let output = clipped_relu_affine_32_to_1_avx2(&l2_out, &self.output);
         #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
         let output = {
             clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
-            self.output.propagate(&l2_relu.0, &mut output_arr);
+            self.output.propagate_7bit(&l2_relu.0, &mut output_arr);
             output_arr[0]
         };
 
@@ -167,19 +167,19 @@ impl<
         let mut l2_relu = Aligned([0u8; OUTPUT_PADDED_INPUT]);
         let mut output_arr = [0i32; 1];
 
-        self.l1.propagate(input, &mut l1_out);
+        self.l1.propagate_7bit(input, &mut l1_out);
         let l1_skip = l1_out[Self::MAIN_DIM];
         l1_sqr_clipped_relu_activation::<LS_L1_OUT, LS_L2_IN>(&l1_out, &mut l2_input.0);
         counts.l1_act_sat += l2_input.0[..LS_L2_IN].iter().filter(|&&v| v == 127).count() as u64;
         counts.l1_act_total += LS_L2_IN as u64;
 
-        self.l2.propagate(&l2_input.0, &mut l2_out);
+        self.l2.propagate_7bit(&l2_input.0, &mut l2_out);
         clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
         counts.l2_act_sat +=
             l2_relu.0[..NNUE_PYTORCH_L3].iter().filter(|&&v| v == 127).count() as u64;
         counts.l2_act_total += NNUE_PYTORCH_L3 as u64;
 
-        self.output.propagate(&l2_relu.0, &mut output_arr);
+        self.output.propagate_7bit(&l2_relu.0, &mut output_arr);
         output_arr[0] + l1_skip
     }
 
@@ -194,18 +194,18 @@ impl<
         let mut l2_relu = Aligned([0u8; OUTPUT_PADDED_INPUT]);
         let mut output_arr = [0i32; 1];
 
-        self.l1.propagate(input, &mut l1_out);
+        self.l1.propagate_7bit(input, &mut l1_out);
 
         // Split: [main_dim, 1]
         let l1_skip = l1_out[Self::MAIN_DIM];
         l1_sqr_clipped_relu_activation::<LS_L1_OUT, LS_L2_IN>(&l1_out, &mut l2_input.0);
 
         // L2: LS_L2_IN → 32
-        self.l2.propagate(&l2_input.0, &mut l2_out);
+        self.l2.propagate_7bit(&l2_input.0, &mut l2_out);
         clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
 
         // Output: 32 → 1
-        self.output.propagate(&l2_relu.0, &mut output_arr);
+        self.output.propagate_7bit(&l2_relu.0, &mut output_arr);
 
         // Skip connection
         let raw_score = output_arr[0] + l1_skip;

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -462,6 +462,22 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
     /// → スパース最適化には高すぎるため、密な行列積方式が正しい選択。
     /// 詳細は `network.rs` の diagnostics 計測コードを参照。
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT_DIM]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    /// 入力が `[0, 127]` に収まることを呼び出し側が保証する場合の順伝播。
+    ///
+    /// 隣接 2 項の `u8 * i8` 和は最悪でも `127 * -128 * 2` で i16 に収まるため、
+    /// `maddubs` を分割せずに使える。全 u8 範囲を渡すと i16 飽和で結果が変わる。
+    pub fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT_DIM]) {
+        debug_assert!(
+            input[..INPUT_DIM].iter().all(|&x| x <= 127),
+            "propagate_7bit received an input above 127"
+        );
+        self.propagate_impl::<false>(input, output);
+    }
+
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT_DIM]) {
         debug_assert!(
             input.len() >= Self::PADDED_INPUT,
             "input length {} is less than PADDED_INPUT {}",
@@ -519,7 +535,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m512_add_dpbusd_epi32::<true>(
+                            m512_add_dpbusd_epi32::<FULL_RANGE>(
                                 &mut acc[k],
                                 in_val,
                                 _mm512_load_si512(col.add(k)),
@@ -590,7 +606,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m256_add_dpbusd_epi32::<true>(
+                            m256_add_dpbusd_epi32::<FULL_RANGE>(
                                 &mut acc[k],
                                 in_val,
                                 _mm256_load_si256(col.add(k)),
@@ -621,7 +637,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
                         let w_vec = _mm256_load_si256(
                             weights_ptr.add(weight_row_offset + offset) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32::<true>(&mut acc, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc, in_vec, w_vec);
                     }
 
                     *out = bias + hsum_i32_avx2(acc);
@@ -678,7 +694,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m128_add_dpbusd_epi32::<true>(
+                            m128_add_dpbusd_epi32::<FULL_RANGE>(
                                 &mut acc[k],
                                 in_val,
                                 _mm_load_si128(col.add(k)),
@@ -709,7 +725,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
                         let w_vec = _mm_load_si128(
                             weights_ptr.add(weight_row_offset + offset) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32::<true>(&mut acc, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc, in_vec, w_vec);
                     }
 
                     *out = bias + hsum_i32_sse2(acc);
@@ -1184,6 +1200,49 @@ mod tests {
                 .unwrap()
                 .propagate(input, output);
         });
+    }
+
+    /// 入力が 7bit に収まる限り、専用経路は全範囲経路と同じ値を返す。
+    #[test]
+    fn propagate_7bit_matches_full_range_for_7bit_input() {
+        fn check<const INPUT: usize, const OUTPUT: usize>() {
+            let padded = padded_input(INPUT);
+            let mut bytes = Vec::new();
+            for o in 0..OUTPUT {
+                bytes.extend_from_slice(&((o as i32) * 91 - 733).to_le_bytes());
+            }
+            let mut state = 0x243f_6a88_85a3_08d3u64;
+            let mut next = move || {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                (state >> 33) as u8
+            };
+            for _ in 0..padded * OUTPUT {
+                bytes.push(next());
+            }
+            let layer = AffineTransform::<INPUT, OUTPUT>::read(&mut &bytes[..]).unwrap();
+
+            let mut input = AlignedBox::<u8>::new_zeroed(padded);
+            for (i, x) in input.iter_mut().take(INPUT).enumerate() {
+                *x = match i % 4 {
+                    0 => 0,
+                    1 => 127,
+                    2 => 126,
+                    _ => next() % 128,
+                };
+            }
+
+            let mut full = [0i32; OUTPUT];
+            let mut seven = [0i32; OUTPUT];
+            layer.propagate(&input, &mut full);
+            layer.propagate_7bit(&input, &mut seven);
+            assert_eq!(full, seven, "INPUT={INPUT}, OUTPUT={OUTPUT}");
+        }
+
+        check::<1536, 16>();
+        check::<32, 32>();
+        check::<32, 1>();
+        check::<512, 8>();
+        check::<760, 8>();
     }
 
     use crate::nnue::accumulator::Aligned;

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -48,7 +48,7 @@ unsafe fn hsum_i32_avx2(v: std::arch::x86_64::__m256i) -> i32 {
 /// 512bit = 64バイト = 16 x i32 を一度に処理。
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512vnni"))]
 #[inline]
-unsafe fn m512_add_dpbusd_epi32(
+unsafe fn m512_add_dpbusd_epi32<const FULL_RANGE: bool>(
     acc: &mut std::arch::x86_64::__m512i,
     a: std::arch::x86_64::__m512i,
     b: std::arch::x86_64::__m512i,
@@ -69,7 +69,7 @@ unsafe fn m512_add_dpbusd_epi32(
     not(target_feature = "avx512vnni")
 ))]
 #[inline]
-unsafe fn m512_add_dpbusd_epi32(
+unsafe fn m512_add_dpbusd_epi32<const FULL_RANGE: bool>(
     acc: &mut std::arch::x86_64::__m512i,
     a: std::arch::x86_64::__m512i,
     b: std::arch::x86_64::__m512i,
@@ -77,22 +77,33 @@ unsafe fn m512_add_dpbusd_epi32(
     // SAFETY: 呼び出し側が avx512bw フィーチャを保証する
     unsafe {
         use std::arch::x86_64::*;
-        // maddubs: u8×i8 → i16 (飽和加算)
-        let product = _mm512_maddubs_epi16(a, b);
-        // madd: i16×i16 → i32 (隣接ペアの積和)
-        let product32 = _mm512_madd_epi16(product, _mm512_set1_epi16(1));
-        *acc = _mm512_add_epi32(*acc, product32);
+        if FULL_RANGE {
+            // 7bit 部分と最上位 bit を別々に積和する。各隣接和は i16 内に
+            // 収まり（最小 -32768）、i32 化してから合算すれば qa255 も飽和しない。
+            let low = _mm512_and_si512(a, _mm512_set1_epi8(127));
+            let high = _mm512_andnot_si512(_mm512_set1_epi8(127), a);
+            let product = _mm512_maddubs_epi16(low, b);
+            let high_product = _mm512_maddubs_epi16(high, b);
+            let high32 = _mm512_madd_epi16(high_product, _mm512_set1_epi16(1));
+            // madd: i16×i16 → i32 (隣接ペアの積和)
+            let product32 = _mm512_madd_epi16(product, _mm512_set1_epi16(1));
+            *acc = _mm512_add_epi32(*acc, _mm512_add_epi32(product32, high32));
+        } else {
+            let product = _mm512_maddubs_epi16(a, b);
+            let product32 = _mm512_madd_epi16(product, _mm512_set1_epi16(1));
+            *acc = _mm512_add_epi32(*acc, product32);
+        }
     }
 }
 
 /// AVX2用 DPBUSD エミュレーション（u8×i8→i32積和演算）
 ///
-/// VNNI非対応CPU向け。`maddubs` + `madd` の2命令で積和演算を実行。
+/// VNNI非対応CPU向け。入力を分割した `maddubs` + `madd` で飽和なしの積和演算を実行。
 /// AVX-512 ビルドでも propagate の AVX2 フォールスルー経路から参照されるため
 /// compile-in する。
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
-unsafe fn m256_add_dpbusd_epi32(
+pub(crate) unsafe fn m256_add_dpbusd_epi32<const FULL_RANGE: bool>(
     acc: &mut std::arch::x86_64::__m256i,
     a: std::arch::x86_64::__m256i,
     b: std::arch::x86_64::__m256i,
@@ -100,9 +111,21 @@ unsafe fn m256_add_dpbusd_epi32(
     // SAFETY: 呼び出し側が avx2 フィーチャを保証する
     unsafe {
         use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
+        if FULL_RANGE {
+            // 7bit 部分と最上位 bit を別々に積和する。各隣接和は i16 内に
+            // 収まり（最小 -32768）、i32 化してから合算すれば qa255 も飽和しない。
+            let low = _mm256_and_si256(a, _mm256_set1_epi8(127));
+            let high = _mm256_andnot_si256(_mm256_set1_epi8(127), a);
+            let product = _mm256_maddubs_epi16(low, b);
+            let high_product = _mm256_maddubs_epi16(high, b);
+            let high32 = _mm256_madd_epi16(high_product, _mm256_set1_epi16(1));
+            let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
+            *acc = _mm256_add_epi32(*acc, _mm256_add_epi32(product32, high32));
+        } else {
+            let product = _mm256_maddubs_epi16(a, b);
+            let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
+            *acc = _mm256_add_epi32(*acc, product32);
+        }
     }
 }
 
@@ -138,7 +161,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     not(target_feature = "avx2")
 ))]
 #[inline]
-unsafe fn m128_add_dpbusd_epi32(
+pub(crate) unsafe fn m128_add_dpbusd_epi32<const FULL_RANGE: bool>(
     acc: &mut std::arch::x86_64::__m128i,
     a: std::arch::x86_64::__m128i,
     b: std::arch::x86_64::__m128i,
@@ -146,9 +169,21 @@ unsafe fn m128_add_dpbusd_epi32(
     // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
     unsafe {
         use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b); // SSSE3命令
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
+        if FULL_RANGE {
+            // 7bit 部分と最上位 bit を別々に積和する。各隣接和は i16 内に
+            // 収まり（最小 -32768）、i32 化してから合算すれば qa255 も飽和しない。
+            let low = _mm_and_si128(a, _mm_set1_epi8(127));
+            let high = _mm_andnot_si128(_mm_set1_epi8(127), a);
+            let product = _mm_maddubs_epi16(low, b);
+            let high_product = _mm_maddubs_epi16(high, b);
+            let high32 = _mm_madd_epi16(high_product, _mm_set1_epi16(1));
+            let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
+            *acc = _mm_add_epi32(*acc, _mm_add_epi32(product32, high32));
+        } else {
+            let product = _mm_maddubs_epi16(a, b);
+            let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
+            *acc = _mm_add_epi32(*acc, product32);
+        }
     }
 }
 
@@ -484,7 +519,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m512_add_dpbusd_epi32(
+                            m512_add_dpbusd_epi32::<true>(
                                 &mut acc[k],
                                 in_val,
                                 _mm512_load_si512(col.add(k)),
@@ -555,7 +590,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m256_add_dpbusd_epi32(
+                            m256_add_dpbusd_epi32::<true>(
                                 &mut acc[k],
                                 in_val,
                                 _mm256_load_si256(col.add(k)),
@@ -573,7 +608,6 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                 // OUTPUT_DIM % 8 != 0 の場合: 従来の実装（出力ごとに処理）
                 let num_chunks = Self::PADDED_INPUT / 32;
-                let one = _mm256_set1_epi16(1);
                 let input_ptr = input.as_ptr();
                 let weights_ptr = self.weights.as_ptr();
 
@@ -587,9 +621,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
                         let w_vec = _mm256_load_si256(
                             weights_ptr.add(weight_row_offset + offset) as *const __m256i
                         );
-                        let prod16 = _mm256_maddubs_epi16(in_vec, w_vec);
-                        let prod32 = _mm256_madd_epi16(prod16, one);
-                        acc = _mm256_add_epi32(acc, prod32);
+                        m256_add_dpbusd_epi32::<true>(&mut acc, in_vec, w_vec);
                     }
 
                     *out = bias + hsum_i32_avx2(acc);
@@ -646,7 +678,11 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                         // 内側: 全出力レジスタに積和演算
                         for k in 0..num_regs {
-                            m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                            m128_add_dpbusd_epi32::<true>(
+                                &mut acc[k],
+                                in_val,
+                                _mm_load_si128(col.add(k)),
+                            );
                         }
                     }
 
@@ -660,7 +696,6 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
                 // OUTPUT_DIM % 4 != 0 の場合: SSSE3の_mm_maddubs_epi16を使う通常版
                 let num_chunks = Self::PADDED_INPUT / 16;
-                let one = _mm_set1_epi16(1);
                 let input_ptr = input.as_ptr();
                 let weights_ptr = self.weights.as_ptr();
 
@@ -674,10 +709,7 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
                         let w_vec = _mm_load_si128(
                             weights_ptr.add(weight_row_offset + offset) as *const __m128i
                         );
-                        // SSSE3: _mm_maddubs_epi16
-                        let prod16 = _mm_maddubs_epi16(in_vec, w_vec);
-                        let prod32 = _mm_madd_epi16(prod16, one);
-                        acc = _mm_add_epi32(acc, prod32);
+                        m128_add_dpbusd_epi32::<true>(&mut acc, in_vec, w_vec);
                     }
 
                     *out = bias + hsum_i32_sse2(acc);
@@ -1069,9 +1101,91 @@ impl<const DIM: usize> ClippedReLU<DIM> {
     }
 }
 
+// read 時のレイアウト変換も含め、全 u8 範囲を整数参照と照合する。
+#[cfg(test)]
+pub(crate) fn check_qa255_affine<const INPUT: usize, const OUTPUT: usize>(
+    propagate: impl Fn(&[u8], &[u8], &mut [i32; OUTPUT]),
+) {
+    let padded = padded_input(INPUT);
+    for qa in [127u8, 128, 255] {
+        for pattern in 0..4 {
+            let mut bytes = Vec::new();
+            let biases: Vec<i32> = (0..OUTPUT).map(|o| o as i32 * 73 - 201).collect();
+            for bias in &biases {
+                bytes.extend_from_slice(&bias.to_le_bytes());
+            }
+            let mut weights = vec![0i8; padded * OUTPUT];
+            for o in 0..OUTPUT {
+                for i in 0..INPUT {
+                    weights[o * padded + i] = match pattern {
+                        0 => 127,
+                        1 => -128,
+                        2 => {
+                            if (i / 2 + o) % 2 == 0 {
+                                127
+                            } else {
+                                -128
+                            }
+                        }
+                        _ => ((i * 37 + o * 19) % 256) as u8 as i8,
+                    };
+                }
+            }
+            bytes.extend(weights.iter().map(|w| *w as u8));
+            let mut input = AlignedBox::<u8>::new_zeroed(padded);
+            for (i, x) in input.iter_mut().take(INPUT).enumerate() {
+                *x = if pattern < 3 {
+                    qa
+                } else {
+                    [0, 1, 126, 127, 128, 129, 254, 255][i % 8].min(qa)
+                };
+            }
+            let mut actual = [0i32; OUTPUT];
+            propagate(&bytes, &input, &mut actual);
+            for o in 0..OUTPUT {
+                let expected = biases[o]
+                    + (0..INPUT)
+                        .map(|i| i32::from(input[i]) * i32::from(weights[o * padded + i]))
+                        .sum::<i32>();
+                assert_eq!(actual[o], expected, "qa={qa}, pattern={pattern}, output={o}");
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        check_qa255_affine::<32, 32>(|bytes, input, output| {
+            AffineTransform::<32, 32>::read(&mut &bytes[..])
+                .unwrap()
+                .propagate(input, output);
+        });
+        check_qa255_affine::<512, 8>(|bytes, input, output| {
+            AffineTransform::<512, 8>::read(&mut &bytes[..])
+                .unwrap()
+                .propagate(input, output);
+        });
+        check_qa255_affine::<32, 4>(|bytes, input, output| {
+            AffineTransform::<32, 4>::read(&mut &bytes[..])
+                .unwrap()
+                .propagate(input, output);
+        });
+        check_qa255_affine::<32, 1>(|bytes, input, output| {
+            AffineTransform::<32, 1>::read(&mut &bytes[..])
+                .unwrap()
+                .propagate(input, output);
+        });
+        check_qa255_affine::<760, 8>(|bytes, input, output| {
+            AffineTransform::<760, 8>::read(&mut &bytes[..])
+                .unwrap()
+                .propagate(input, output);
+        });
+    }
+
     use crate::nnue::accumulator::Aligned;
 
     fn affine_file_bytes<const INPUT: usize, const OUTPUT: usize>(weight: i8) -> Vec<u8> {

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -1158,7 +1158,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         check_qa255_affine::<32, 32>(|bytes, input, output| {
             AffineTransform::<32, 32>::read(&mut &bytes[..])
                 .unwrap()

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
@@ -63,20 +63,7 @@ fn nnue_debug_enabled() -> bool {
 // =============================================================================
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-#[inline]
-unsafe fn m256_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m256i,
-    a: std::arch::x86_64::__m256i,
-    b: std::arch::x86_64::__m256i,
-) {
-    // SAFETY: 呼び出し側が avx2 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m256_add_dpbusd_epi32;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
@@ -119,20 +106,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     target_feature = "ssse3",
     not(target_feature = "avx2")
 ))]
-#[inline]
-unsafe fn m128_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m128i,
-    a: std::arch::x86_64::__m128i,
-    b: std::arch::x86_64::__m128i,
-) {
-    // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b);
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m128_add_dpbusd_epi32;
 
 // =============================================================================
 // AccumulatorHalfKaHmMerged - const generics 版アキュムレータ
@@ -1150,11 +1124,23 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
 
     /// 順伝播（SIMD最適化版 - ループ逆転）
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    // 活性化関数の出力契約が 0..=127 を保証する呼び出し専用。
+    #[inline]
+    fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        debug_assert!(input.iter().all(|&x| x <= 127));
+        self.propagate_impl::<false>(input, output);
+    }
+
+    #[inline]
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
         // AVX2: ループ逆転最適化版
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             unsafe {
-                self.propagate_avx2_loop_inverted(input, output);
+                self.propagate_avx2_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1166,7 +1152,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         ))]
         {
             unsafe {
-                self.propagate_ssse3_loop_inverted(input, output);
+                self.propagate_ssse3_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1305,7 +1291,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
     #[inline]
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_avx2_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_avx2_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が avx2 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1337,7 +1327,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
 
                     // 内側ループ: 全出力レジスタに積和演算
                     for k in 0..num_regs {
-                        m256_add_dpbusd_epi32(&mut acc[k], in_val, _mm256_load_si256(col.add(k)));
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm256_load_si256(col.add(k)),
+                        );
                     }
                 }
 
@@ -1363,7 +1357,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
                         let w_vec = _mm256_load_si256(
                             weight_ptr.add(row_offset + chunk * 32) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_avx2(acc_simd);
@@ -1383,7 +1377,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
     // iterator 化すると raw pointer 側のオフセットを別途 track する必要があり、
     // SIMD intrinsic の autovectorization を阻害し得る。range ループのまま保つ。
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_ssse3_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_ssse3_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1410,7 +1408,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
                     let col = weights_ptr.add(i * OUTPUT * Self::CHUNK_SIZE) as *const __m128i;
 
                     for k in 0..num_regs {
-                        m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm_load_si128(col.add(k)),
+                        );
                     }
                 }
 
@@ -1434,7 +1436,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
                         let w_vec = _mm_load_si128(
                             weight_ptr.add(row_offset + chunk * 16) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_sse2(acc_simd);
@@ -1690,7 +1692,11 @@ impl<
 
         // l1 層 - 64バイトアライン
         let mut l1_out: Aligned<[i32; L2]> = unsafe { Aligned::new_uninit() };
-        self.l1.propagate(&transformed.0, &mut l1_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 && self.qa <= 127 {
+            self.l1.propagate_7bit(&transformed.0, &mut l1_out.0);
+        } else {
+            self.l1.propagate(&transformed.0, &mut l1_out.0);
+        }
 
         if debug {
             eprintln!("[DEBUG] L1 output: {:?}", &l1_out.0);
@@ -1719,7 +1725,11 @@ impl<
 
         // l2 層 - 64バイトアライン
         let mut l2_out: Aligned<[i32; L3]> = unsafe { Aligned::new_uninit() };
-        self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.l2.propagate_7bit(&l1_relu.0, &mut l2_out.0);
+        } else {
+            self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        }
 
         // デバッグ: L2出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1740,7 +1750,11 @@ impl<
 
         // output 層（4バイトなのでゼロ初期化のコストは無視可能）
         let mut output = [0i32; 1];
-        self.output.propagate(&l2_relu.0, &mut output);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.output.propagate_7bit(&l2_relu.0, &mut output);
+        } else {
+            self.output.propagate(&l2_relu.0, &mut output);
+        }
 
         // スケーリング
         let fv_scale = get_fv_scale_override().unwrap_or(self.fv_scale);
@@ -1879,6 +1893,54 @@ pub type HalfKaHmMerged768Pairwise = NetworkHalfKaHmMerged<768, 1536, 768, 16, 6
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmMerged::<32, 32>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<512, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmMerged::<512, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 4>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmMerged::<32, 4>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 1>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmMerged::<32, 1>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<760, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmMerged::<760, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+    }
 
     /// read→propagate を、SIMD レイアウト（スクランブル形式
     /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
@@ -1894,7 +1894,7 @@ pub type HalfKaHmMerged768Pairwise = NetworkHalfKaHmMerged<768, 1536, 768, 16, 6
 mod tests {
     use super::*;
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
             let transform = AffineTransformHalfKaHmMerged::<32, 32>::read(&mut &bytes[..]).unwrap();
             transform.propagate(input, output);

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -65,20 +65,7 @@ fn nnue_debug_enabled() -> bool {
 // =============================================================================
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-#[inline]
-unsafe fn m256_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m256i,
-    a: std::arch::x86_64::__m256i,
-    b: std::arch::x86_64::__m256i,
-) {
-    // SAFETY: 呼び出し側が avx2 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m256_add_dpbusd_epi32;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
@@ -121,20 +108,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     target_feature = "ssse3",
     not(target_feature = "avx2")
 ))]
-#[inline]
-unsafe fn m128_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m128i,
-    a: std::arch::x86_64::__m128i,
-    b: std::arch::x86_64::__m128i,
-) {
-    // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b);
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m128_add_dpbusd_epi32;
 
 // =============================================================================
 // AccumulatorHalfKaHmSplit - const generics 版アキュムレータ
@@ -1152,11 +1126,23 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
 
     /// 順伝播（SIMD最適化版 - ループ逆転）
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    // 活性化関数の出力契約が 0..=127 を保証する呼び出し専用。
+    #[inline]
+    fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        debug_assert!(input.iter().all(|&x| x <= 127));
+        self.propagate_impl::<false>(input, output);
+    }
+
+    #[inline]
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
         // AVX2: ループ逆転最適化版
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             unsafe {
-                self.propagate_avx2_loop_inverted(input, output);
+                self.propagate_avx2_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1168,7 +1154,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         ))]
         {
             unsafe {
-                self.propagate_ssse3_loop_inverted(input, output);
+                self.propagate_ssse3_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1307,7 +1293,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
     #[inline]
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_avx2_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_avx2_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が avx2 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1339,7 +1329,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
 
                     // 内側ループ: 全出力レジスタに積和演算
                     for k in 0..num_regs {
-                        m256_add_dpbusd_epi32(&mut acc[k], in_val, _mm256_load_si256(col.add(k)));
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm256_load_si256(col.add(k)),
+                        );
                     }
                 }
 
@@ -1365,7 +1359,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
                         let w_vec = _mm256_load_si256(
                             weight_ptr.add(row_offset + chunk * 32) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_avx2(acc_simd);
@@ -1385,7 +1379,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
     // iterator 化すると raw pointer 側のオフセットを別途 track する必要があり、
     // SIMD intrinsic の autovectorization を阻害し得る。range ループのまま保つ。
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_ssse3_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_ssse3_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1412,7 +1410,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
                     let col = weights_ptr.add(i * OUTPUT * Self::CHUNK_SIZE) as *const __m128i;
 
                     for k in 0..num_regs {
-                        m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm_load_si128(col.add(k)),
+                        );
                     }
                 }
 
@@ -1436,7 +1438,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
                         let w_vec = _mm_load_si128(
                             weight_ptr.add(row_offset + chunk * 16) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_sse2(acc_simd);
@@ -1692,7 +1694,11 @@ impl<
 
         // l1 層 - 64バイトアライン
         let mut l1_out: Aligned<[i32; L2]> = unsafe { Aligned::new_uninit() };
-        self.l1.propagate(&transformed.0, &mut l1_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 && self.qa <= 127 {
+            self.l1.propagate_7bit(&transformed.0, &mut l1_out.0);
+        } else {
+            self.l1.propagate(&transformed.0, &mut l1_out.0);
+        }
 
         if debug {
             eprintln!("[DEBUG] L1 output: {:?}", &l1_out.0);
@@ -1721,7 +1727,11 @@ impl<
 
         // l2 層 - 64バイトアライン
         let mut l2_out: Aligned<[i32; L3]> = unsafe { Aligned::new_uninit() };
-        self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.l2.propagate_7bit(&l1_relu.0, &mut l2_out.0);
+        } else {
+            self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        }
 
         // デバッグ: L2出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1742,7 +1752,11 @@ impl<
 
         // output 層（4バイトなのでゼロ初期化のコストは無視可能）
         let mut output = [0i32; 1];
-        self.output.propagate(&l2_relu.0, &mut output);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.output.propagate_7bit(&l2_relu.0, &mut output);
+        } else {
+            self.output.propagate(&l2_relu.0, &mut output);
+        }
 
         // スケーリング
         let fv_scale = get_fv_scale_override().unwrap_or(self.fv_scale);
@@ -1880,6 +1894,54 @@ pub type HalfKaHmSplit768Pairwise = NetworkHalfKaHmSplit<768, 1536, 768, 16, 64,
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmSplit::<32, 32>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<512, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmSplit::<512, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 4>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmSplit::<32, 4>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 1>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmSplit::<32, 1>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<760, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaHmSplit::<760, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+    }
 
     /// read→propagate を、SIMD レイアウト（スクランブル形式
     /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -1895,7 +1895,7 @@ pub type HalfKaHmSplit768Pairwise = NetworkHalfKaHmSplit<768, 1536, 768, 16, 64,
 mod tests {
     use super::*;
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
             let transform = AffineTransformHalfKaHmSplit::<32, 32>::read(&mut &bytes[..]).unwrap();
             transform.propagate(input, output);

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -65,20 +65,7 @@ fn nnue_debug_enabled() -> bool {
 // =============================================================================
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-#[inline]
-unsafe fn m256_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m256i,
-    a: std::arch::x86_64::__m256i,
-    b: std::arch::x86_64::__m256i,
-) {
-    // SAFETY: 呼び出し側が avx2 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m256_add_dpbusd_epi32;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
@@ -121,20 +108,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     target_feature = "ssse3",
     not(target_feature = "avx2")
 ))]
-#[inline]
-unsafe fn m128_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m128i,
-    a: std::arch::x86_64::__m128i,
-    b: std::arch::x86_64::__m128i,
-) {
-    // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b);
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m128_add_dpbusd_epi32;
 
 // =============================================================================
 // AccumulatorHalfKaMerged - const generics 版アキュムレータ
@@ -1152,11 +1126,23 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
 
     /// 順伝播（SIMD最適化版 - ループ逆転）
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    // 活性化関数の出力契約が 0..=127 を保証する呼び出し専用。
+    #[inline]
+    fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        debug_assert!(input.iter().all(|&x| x <= 127));
+        self.propagate_impl::<false>(input, output);
+    }
+
+    #[inline]
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
         // AVX2: ループ逆転最適化版
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             unsafe {
-                self.propagate_avx2_loop_inverted(input, output);
+                self.propagate_avx2_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1168,7 +1154,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         ))]
         {
             unsafe {
-                self.propagate_ssse3_loop_inverted(input, output);
+                self.propagate_ssse3_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1309,7 +1295,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
     #[inline]
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_avx2_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_avx2_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が avx2 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1341,7 +1331,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
 
                     // 内側ループ: 全出力レジスタに積和演算
                     for k in 0..num_regs {
-                        m256_add_dpbusd_epi32(&mut acc[k], in_val, _mm256_load_si256(col.add(k)));
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm256_load_si256(col.add(k)),
+                        );
                     }
                 }
 
@@ -1367,7 +1361,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
                         let w_vec = _mm256_load_si256(
                             weight_ptr.add(row_offset + chunk * 32) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_avx2(acc_simd);
@@ -1387,7 +1381,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
     // iterator 化すると raw pointer 側のオフセットを別途 track する必要があり、
     // SIMD intrinsic の autovectorization を阻害し得る。range ループのまま保つ。
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_ssse3_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_ssse3_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1414,7 +1412,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
                     let col = weights_ptr.add(i * OUTPUT * Self::CHUNK_SIZE) as *const __m128i;
 
                     for k in 0..num_regs {
-                        m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm_load_si128(col.add(k)),
+                        );
                     }
                 }
 
@@ -1438,7 +1440,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
                         let w_vec = _mm_load_si128(
                             weight_ptr.add(row_offset + chunk * 16) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_sse2(acc_simd);
@@ -1694,7 +1696,11 @@ impl<
 
         // l1 層 - 64バイトアライン
         let mut l1_out: Aligned<[i32; L2]> = unsafe { Aligned::new_uninit() };
-        self.l1.propagate(&transformed.0, &mut l1_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 && self.qa <= 127 {
+            self.l1.propagate_7bit(&transformed.0, &mut l1_out.0);
+        } else {
+            self.l1.propagate(&transformed.0, &mut l1_out.0);
+        }
 
         if debug {
             eprintln!("[DEBUG] L1 output: {:?}", &l1_out.0);
@@ -1723,7 +1729,11 @@ impl<
 
         // l2 層 - 64バイトアライン
         let mut l2_out: Aligned<[i32; L3]> = unsafe { Aligned::new_uninit() };
-        self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.l2.propagate_7bit(&l1_relu.0, &mut l2_out.0);
+        } else {
+            self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        }
 
         // デバッグ: L2出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1744,7 +1754,11 @@ impl<
 
         // output 層（4バイトなのでゼロ初期化のコストは無視可能）
         let mut output = [0i32; 1];
-        self.output.propagate(&l2_relu.0, &mut output);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.output.propagate_7bit(&l2_relu.0, &mut output);
+        } else {
+            self.output.propagate(&l2_relu.0, &mut output);
+        }
 
         // スケーリング
         let fv_scale = get_fv_scale_override().unwrap_or(self.fv_scale);
@@ -1881,6 +1895,54 @@ pub type HalfKaMerged768Pairwise = NetworkHalfKaMerged<768, 1536, 768, 16, 64, P
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaMerged::<32, 32>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<512, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaMerged::<512, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 4>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaMerged::<32, 4>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 1>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaMerged::<32, 1>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<760, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaMerged::<760, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+    }
 
     /// read→propagate を、SIMD レイアウト（スクランブル形式
     /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -1896,7 +1896,7 @@ pub type HalfKaMerged768Pairwise = NetworkHalfKaMerged<768, 1536, 768, 16, 64, P
 mod tests {
     use super::*;
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
             let transform = AffineTransformHalfKaMerged::<32, 32>::read(&mut &bytes[..]).unwrap();
             transform.propagate(input, output);

--- a/crates/rshogi-core/src/nnue/network_halfka_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_split.rs
@@ -63,20 +63,7 @@ fn nnue_debug_enabled() -> bool {
 // =============================================================================
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-#[inline]
-unsafe fn m256_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m256i,
-    a: std::arch::x86_64::__m256i,
-    b: std::arch::x86_64::__m256i,
-) {
-    // SAFETY: 呼び出し側が avx2 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m256_add_dpbusd_epi32;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
@@ -119,20 +106,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     target_feature = "ssse3",
     not(target_feature = "avx2")
 ))]
-#[inline]
-unsafe fn m128_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m128i,
-    a: std::arch::x86_64::__m128i,
-    b: std::arch::x86_64::__m128i,
-) {
-    // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b);
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m128_add_dpbusd_epi32;
 
 // =============================================================================
 // AccumulatorHalfKaSplit - const generics 版アキュムレータ
@@ -1150,11 +1124,23 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
 
     /// 順伝播（SIMD最適化版 - ループ逆転）
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    // 活性化関数の出力契約が 0..=127 を保証する呼び出し専用。
+    #[inline]
+    fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        debug_assert!(input.iter().all(|&x| x <= 127));
+        self.propagate_impl::<false>(input, output);
+    }
+
+    #[inline]
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
         // AVX2: ループ逆転最適化版
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             unsafe {
-                self.propagate_avx2_loop_inverted(input, output);
+                self.propagate_avx2_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1166,7 +1152,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         ))]
         {
             unsafe {
-                self.propagate_ssse3_loop_inverted(input, output);
+                self.propagate_ssse3_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1307,7 +1293,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
     #[inline]
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_avx2_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_avx2_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が avx2 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1339,7 +1329,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
 
                     // 内側ループ: 全出力レジスタに積和演算
                     for k in 0..num_regs {
-                        m256_add_dpbusd_epi32(&mut acc[k], in_val, _mm256_load_si256(col.add(k)));
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm256_load_si256(col.add(k)),
+                        );
                     }
                 }
 
@@ -1365,7 +1359,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
                         let w_vec = _mm256_load_si256(
                             weight_ptr.add(row_offset + chunk * 32) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_avx2(acc_simd);
@@ -1385,7 +1379,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
     // iterator 化すると raw pointer 側のオフセットを別途 track する必要があり、
     // SIMD intrinsic の autovectorization を阻害し得る。range ループのまま保つ。
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_ssse3_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_ssse3_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1412,7 +1410,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
                     let col = weights_ptr.add(i * OUTPUT * Self::CHUNK_SIZE) as *const __m128i;
 
                     for k in 0..num_regs {
-                        m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm_load_si128(col.add(k)),
+                        );
                     }
                 }
 
@@ -1436,7 +1438,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
                         let w_vec = _mm_load_si128(
                             weight_ptr.add(row_offset + chunk * 16) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_sse2(acc_simd);
@@ -1692,7 +1694,11 @@ impl<
 
         // l1 層 - 64バイトアライン
         let mut l1_out: Aligned<[i32; L2]> = unsafe { Aligned::new_uninit() };
-        self.l1.propagate(&transformed.0, &mut l1_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 && self.qa <= 127 {
+            self.l1.propagate_7bit(&transformed.0, &mut l1_out.0);
+        } else {
+            self.l1.propagate(&transformed.0, &mut l1_out.0);
+        }
 
         if debug {
             eprintln!("[DEBUG] L1 output: {:?}", &l1_out.0);
@@ -1721,7 +1727,11 @@ impl<
 
         // l2 層 - 64バイトアライン
         let mut l2_out: Aligned<[i32; L3]> = unsafe { Aligned::new_uninit() };
-        self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.l2.propagate_7bit(&l1_relu.0, &mut l2_out.0);
+        } else {
+            self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        }
 
         // デバッグ: L2出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1742,7 +1752,11 @@ impl<
 
         // output 層（4バイトなのでゼロ初期化のコストは無視可能）
         let mut output = [0i32; 1];
-        self.output.propagate(&l2_relu.0, &mut output);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.output.propagate_7bit(&l2_relu.0, &mut output);
+        } else {
+            self.output.propagate(&l2_relu.0, &mut output);
+        }
 
         // スケーリング
         let fv_scale = get_fv_scale_override().unwrap_or(self.fv_scale);
@@ -1877,6 +1891,54 @@ pub type HalfKaSplit768Pairwise = NetworkHalfKaSplit<768, 1536, 768, 16, 64, Pai
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaSplit::<32, 32>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<512, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaSplit::<512, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 4>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaSplit::<32, 4>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 1>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaSplit::<32, 1>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<760, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKaSplit::<760, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+    }
 
     /// read→propagate を、SIMD レイアウト（スクランブル形式
     /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で

--- a/crates/rshogi-core/src/nnue/network_halfka_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_split.rs
@@ -1892,7 +1892,7 @@ pub type HalfKaSplit768Pairwise = NetworkHalfKaSplit<768, 1536, 768, 16, 64, Pai
 mod tests {
     use super::*;
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
             let transform = AffineTransformHalfKaSplit::<32, 32>::read(&mut &bytes[..]).unwrap();
             transform.propagate(input, output);

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -1955,7 +1955,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn qa255_affine_matches_integer_reference() {
+    fn qa255_affine_reference_matches_integer() {
         super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
             let transform = AffineTransformHalfKP::<32, 32>::read(&mut &bytes[..]).unwrap();
             transform.propagate(input, output);

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -54,20 +54,7 @@ use crate::types::{Color, Value};
 // =============================================================================
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-#[inline]
-unsafe fn m256_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m256i,
-    a: std::arch::x86_64::__m256i,
-    b: std::arch::x86_64::__m256i,
-) {
-    // SAFETY: 呼び出し側が avx2 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm256_maddubs_epi16(a, b);
-        let product32 = _mm256_madd_epi16(product, _mm256_set1_epi16(1));
-        *acc = _mm256_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m256_add_dpbusd_epi32;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
@@ -110,20 +97,7 @@ unsafe fn hsum_i32_sse2(v: std::arch::x86_64::__m128i) -> i32 {
     target_feature = "ssse3",
     not(target_feature = "avx2")
 ))]
-#[inline]
-unsafe fn m128_add_dpbusd_epi32(
-    acc: &mut std::arch::x86_64::__m128i,
-    a: std::arch::x86_64::__m128i,
-    b: std::arch::x86_64::__m128i,
-) {
-    // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
-    unsafe {
-        use std::arch::x86_64::*;
-        let product = _mm_maddubs_epi16(a, b);
-        let product32 = _mm_madd_epi16(product, _mm_set1_epi16(1));
-        *acc = _mm_add_epi32(*acc, product32);
-    }
-}
+use super::layers::m128_add_dpbusd_epi32;
 
 // =============================================================================
 // AccumulatorHalfKP - const generics 版アキュムレータ
@@ -1257,11 +1231,23 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
 
     /// 順伝播（SIMD最適化版 - ループ逆転）
     pub fn propagate(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        self.propagate_impl::<true>(input, output);
+    }
+
+    // 活性化関数の出力契約が 0..=127 を保証する呼び出し専用。
+    #[inline]
+    fn propagate_7bit(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+        debug_assert!(input.iter().all(|&x| x <= 127));
+        self.propagate_impl::<false>(input, output);
+    }
+
+    #[inline]
+    fn propagate_impl<const FULL_RANGE: bool>(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
         // AVX2: ループ逆転最適化版
         #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             unsafe {
-                self.propagate_avx2_loop_inverted(input, output);
+                self.propagate_avx2_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1273,7 +1259,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         ))]
         {
             unsafe {
-                self.propagate_ssse3_loop_inverted(input, output);
+                self.propagate_ssse3_loop_inverted::<FULL_RANGE>(input, output);
             }
         }
 
@@ -1412,7 +1398,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
     #[inline]
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_avx2_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_avx2_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が avx2 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1444,7 +1434,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
 
                     // 内側ループ: 全出力レジスタに積和演算
                     for k in 0..num_regs {
-                        m256_add_dpbusd_epi32(&mut acc[k], in_val, _mm256_load_si256(col.add(k)));
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm256_load_si256(col.add(k)),
+                        );
                     }
                 }
 
@@ -1470,7 +1464,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
                         let w_vec = _mm256_load_si256(
                             weight_ptr.add(row_offset + chunk * 32) as *const __m256i
                         );
-                        m256_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m256_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_avx2(acc_simd);
@@ -1490,7 +1484,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
     // iterator 化すると raw pointer 側のオフセットを別途 track する必要があり、
     // SIMD intrinsic の autovectorization を阻害し得る。range ループのまま保つ。
     #[allow(clippy::needless_range_loop)]
-    unsafe fn propagate_ssse3_loop_inverted(&self, input: &[u8], output: &mut [i32; OUTPUT]) {
+    unsafe fn propagate_ssse3_loop_inverted<const FULL_RANGE: bool>(
+        &self,
+        input: &[u8],
+        output: &mut [i32; OUTPUT],
+    ) {
         // SAFETY: 呼び出し側が ssse3 フィーチャを保証する
         unsafe {
             use std::arch::x86_64::*;
@@ -1517,7 +1515,11 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
                     let col = weights_ptr.add(i * OUTPUT * Self::CHUNK_SIZE) as *const __m128i;
 
                     for k in 0..num_regs {
-                        m128_add_dpbusd_epi32(&mut acc[k], in_val, _mm_load_si128(col.add(k)));
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(
+                            &mut acc[k],
+                            in_val,
+                            _mm_load_si128(col.add(k)),
+                        );
                     }
                 }
 
@@ -1541,7 +1543,7 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
                         let w_vec = _mm_load_si128(
                             weight_ptr.add(row_offset + chunk * 16) as *const __m128i
                         );
-                        m128_add_dpbusd_epi32(&mut acc_simd, in_vec, w_vec);
+                        m128_add_dpbusd_epi32::<FULL_RANGE>(&mut acc_simd, in_vec, w_vec);
                     }
 
                     *out += hsum_i32_sse2(acc_simd);
@@ -1757,7 +1759,11 @@ impl<
 
         // l1 層 - 64バイトアライン
         let mut l1_out: AlignedGeneric<[i32; L2]> = unsafe { AlignedGeneric::new_uninit() };
-        self.l1.propagate(&transformed.0, &mut l1_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 && self.qa <= 127 {
+            self.l1.propagate_7bit(&transformed.0, &mut l1_out.0);
+        } else {
+            self.l1.propagate(&transformed.0, &mut l1_out.0);
+        }
 
         // デバッグ: L1出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1778,7 +1784,11 @@ impl<
 
         // l2 層 - 64バイトアライン
         let mut l2_out: AlignedGeneric<[i32; L3]> = unsafe { AlignedGeneric::new_uninit() };
-        self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.l2.propagate_7bit(&l1_relu.0, &mut l2_out.0);
+        } else {
+            self.l2.propagate(&l1_relu.0, &mut l2_out.0);
+        }
 
         // デバッグ: L2出力の範囲チェック
         #[cfg(debug_assertions)]
@@ -1799,7 +1809,11 @@ impl<
 
         // output 層（4バイトなのでゼロ初期化のコストは無視可能）
         let mut output = [0i32; 1];
-        self.output.propagate(&l2_relu.0, &mut output);
+        if A::SEVEN_BIT_WHEN_QA127 {
+            self.output.propagate_7bit(&l2_relu.0, &mut output);
+        } else {
+            self.output.propagate(&l2_relu.0, &mut output);
+        }
 
         // スケーリング
         let fv_scale = get_fv_scale_override().unwrap_or(self.fv_scale);
@@ -1939,6 +1953,55 @@ pub type HalfKP768Pairwise = NetworkHalfKP<768, 1536, 768, 16, 64, PairwiseCReLU
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn qa255_affine_matches_integer_reference() {
+        super::super::layers::check_qa255_affine::<32, 32>(|bytes, input, output| {
+            let transform = AffineTransformHalfKP::<32, 32>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<512, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKP::<512, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 4>(|bytes, input, output| {
+            let transform = AffineTransformHalfKP::<32, 4>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<32, 1>(|bytes, input, output| {
+            let transform = AffineTransformHalfKP::<32, 1>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+        super::super::layers::check_qa255_affine::<760, 8>(|bytes, input, output| {
+            let transform = AffineTransformHalfKP::<760, 8>::read(&mut &bytes[..]).unwrap();
+            transform.propagate(input, output);
+            if input.iter().all(|&x| x <= 127) {
+                let expected = *output;
+                transform.propagate_7bit(input, output);
+                assert_eq!(*output, expected);
+            }
+        });
+    }
 
     /// read→propagate を、SIMD レイアウト（スクランブル形式
     /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で


### PR DESCRIPTION
qa255 CReLU の入力と i8 境界重みで、SSSE3/AVX2 の隣接積和が i16 に飽和し、SSE2 と評価結果が変わる問題を修正します。入力を 7bit 部分と最上位 bit に分け、各積和を i32 に拡張してから加算します。qa255 の数値契約を維持し、127 への丸めは行いません。

対象は generic dense、HalfKP、同じ原因が到達する HalfKa の4専用variantです。AVX512BWの非VNNI経路も修正し、専用variantの重複helperを共有します。公開propagateは全u8範囲を扱います。組込み活性化で127上限が保証される経路は従来の積和を使い、独自FtActivationは既定で全範囲経路に残します。

## 検証

- cargo fmt / cargo clippy --fix --allow-dirty --tests / cargo test / tracked絶対パス検査：成功。必須native Clippyは警告なし。
- 独立Codexレビュー2件：最終差分をAPPROVE。
- SSE2 / SSSE3 / AVX2：各6経路の整数参照テスト成功。qa127/128/255、重み127/-128/交互/混合、出力1/4/8/32、入力padding、7bit/full経路一致を確認。
- AVX512BW / AVX512VNNI：compile check成功（実行可能なCPUなし）。Wasm SIMD128もcompile check成功（変更していないWasm/searchコードに既存警告5件）。
- 実モデル tatara-baseline-v2-160.bin（HalfKP256x2-32-32、qa127、SHA256 8b540c1e29e54e5ea82370cac121d9edbb869481b37932c9ec1bdc3b2f3f5f92）の3局面を毎回fresh構築し、static/dynamic比較。全3CPU経路で127/46/149と一致。
- 同じ重みのheaderだけをqa128/255に変更した合成fixtureでもstatic/dynamicと3CPU経路が一致：qa128=138/57/161、qa255=644/525/517。これはqa255で学習された実モデルの検証ではありません。

## 速度と検証の限界

Ryzen5950X、release AVX2、同じqa127実モデル・3固定局面・各200万回evalのABBA比較では、base合計1,797,385,479ns、修正後1,804,597,883ns（比1.0040）。各局面のaccumulatorと評価値は計時前にfresh比較済みです。他ビルドと同時実行した限定的な測定で、速度同等性の証明や探索NPS・棋力の採否判定ではありません。公開genericの全範囲経路は追加演算を伴います。

qa255学習済み実モデル、AVX512/Wasm実行、対局評価は未検証です。LayerStacksの127上限経路と別指摘の未初期化ストレージ問題は変更していません。既存Issue #807の構造体統合全体を完了するPRではありません。
