### PR TITLE
fix(search): apply PASS bonus consistently to completed scores

### DIFF
--- a/crates/rshogi-core/src/eval/material.rs
+++ b/crates/rshogi-core/src/eval/material.rs
@@ -99,7 +99,9 @@ pub fn evaluate_pass_rights(pos: &Position, ply: u16) -> Value {
 ///
 /// 正の値を設定するとパス手が選ばれやすくなる。
 /// USI オプション PassMoveBonus で調整可能。
-/// 手数によるスケーリングは行わず、常に設定値の100%が適用される。
+/// root・内部探索・MultiPV で、手数によるスケーリングなしに適用する。
+/// 詰みスコアと中断値には適用せず、通常スコアは詰み領域の手前で飽和する。
+/// 非ゼロ設定の PASS は子を full PV window で探索するため、探索ノード数が増える場合がある。
 const DEFAULT_PASS_MOVE_BONUS: i32 = 0;
 
 /// ランタイムで切り替え可能なパス手ボーナス

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -2182,15 +2182,12 @@ fn detect_layer_stacks_feature_set(arch_str: &str) -> Result<super::spec::Featur
 mod tests {
     #[cfg(feature = "layerstack-arch")]
     use super::*;
-    use crate::nnue::constants::NNUE_PYTORCH_L1;
     #[cfg(all(
         feature = "layerstack-arch",
         feature = "layerstacks-1536x16x32",
         feature = "ft-halfka_hm_merged"
     ))]
     use crate::position::{Position, SFEN_HIRATE};
-
-    const TEST_L1: usize = NNUE_PYTORCH_L1;
 
     #[cfg(feature = "layerstack-arch")]
     #[test]
@@ -2447,6 +2444,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_load_layer_stacks_file() {
+        const TEST_L1: usize = crate::nnue::constants::NNUE_PYTORCH_L1;
         let routing_guard = crate::nnue::network::layer_stack_routing_test_guard();
         use crate::nnue::layer_stacks::{compute_bucket_index, sqr_clipped_relu_transform};
 

--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -393,11 +393,20 @@ impl Position {
     /// TT等に保存された16bit指し手を安全に取り出す
     /// - 無効な符号化や手番不一致の手はNone
     /// - 合法性までは保証しないが、明らかに不整合な手を弾く
-    /// - 駒情報（moved_piece_after）を上位16bitに付加して返す
+    /// - 通常手は駒情報（moved_piece_after）を上位16bitに付加して返す
+    /// - PASSは盤面やパス権に依存せず保持する。可否は can_pass() で別途判定する
+    /// - WINは着手ではなく宣言勝ちの結果なのでNone。declaration_win() で判定する
     pub fn to_move(&self, mv: Move) -> Option<Move> {
         // 下位16bitの符号化を先に検証する。
         // TT競合で壊れた move16 をここで弾き、probe() 側でcontinueできるようにする。
-        Move::from_u16_checked(mv.raw())?;
+        let mv = Move::from_u16_checked(mv.raw())?;
+
+        if mv.is_pass() {
+            return Some(Move::PASS);
+        }
+        if mv.is_win() {
+            return None;
+        }
 
         if mv.is_none() {
             return Some(Move::NONE);

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1387,7 +1387,31 @@ impl SearchWorker {
                 self.root_quiet_stat_score(mover, mv)
             };
             self.state.stack[0].stat_score = root_stat_score;
-            let value = if move_count == 1 {
+            let pass_bonus = if mv.is_pass() {
+                get_scaled_pass_move_bonus(pos.game_ply())
+            } else {
+                0
+            };
+            // 非ゼロ PASS は mate を除外する加算のため、狭い窓の bound を流用しない。
+            let value = if pass_bonus != 0 {
+                new_depth = self.root_extend_new_depth(
+                    mv,
+                    tt_move_root,
+                    tt_value_root,
+                    tt_data.depth,
+                    new_depth,
+                );
+                -self.search_node_wrapper::<{ NodeType::PV as u8 }>(
+                    pos,
+                    new_depth,
+                    -Value::INFINITE,
+                    Value::INFINITE,
+                    1,
+                    false,
+                    limits,
+                    time_manager,
+                )
+            } else if move_count == 1 {
                 new_depth = self.root_extend_new_depth(
                     mv,
                     tt_move_root,
@@ -1607,6 +1631,7 @@ impl SearchWorker {
             if self.state.abort {
                 return Value::ZERO;
             }
+            let value = apply_pass_move_bonus(value, pass_bonus);
 
             // averageScore/meanSquaredScoreは全rootムーブに対して更新
             {
@@ -2007,7 +2032,31 @@ impl SearchWorker {
             let mut new_depth = depth - 1;
 
             // PVS: 最初の手（このPVラインの候補）はPV探索
-            let value = if rm_idx == pv_idx {
+            let pass_bonus = if mv.is_pass() {
+                get_scaled_pass_move_bonus(pos.game_ply())
+            } else {
+                0
+            };
+            // 非ゼロ PASS は mate を除外する加算のため、狭い窓の bound を流用しない。
+            let value = if pass_bonus != 0 {
+                new_depth = self.root_extend_new_depth(
+                    mv,
+                    tt_move_root,
+                    tt_value_root,
+                    tt_data.depth,
+                    new_depth,
+                );
+                -self.search_node_wrapper::<{ NodeType::PV as u8 }>(
+                    pos,
+                    new_depth,
+                    -Value::INFINITE,
+                    Value::INFINITE,
+                    1,
+                    false,
+                    limits,
+                    time_manager,
+                )
+            } else if rm_idx == pv_idx {
                 new_depth = self.root_extend_new_depth(
                     mv,
                     tt_move_root,
@@ -2216,6 +2265,7 @@ impl SearchWorker {
             if self.state.abort {
                 return Value::ZERO;
             }
+            let value = apply_pass_move_bonus(value, pass_bonus);
 
             // スコア更新
             let mut updated_alpha = rm_idx == pv_idx; // PVラインの先頭は維持
@@ -3093,7 +3143,33 @@ impl SearchWorker {
             // =============================================================
             // 探索
             // =============================================================
-            let mut value = if depth >= 2 && move_count > 1 {
+            let pass_bonus = if mv.is_pass() {
+                get_scaled_pass_move_bonus(pos.game_ply())
+            } else {
+                0
+            };
+            let mut value = if pass_bonus != 0 {
+                if mv == tt_move
+                    && ((tt_value != Value::NONE && tt_value.is_mate_score() && tt_data.depth > 0)
+                        || (tt_data.depth > 1 && st.root_depth > 8))
+                {
+                    new_depth = new_depth.max(1);
+                }
+                st.stack[ply as usize].reduction = 0;
+                st.set_child_follow_pv(ply, mv);
+                -Self::search_node::<{ NodeType::PV as u8 }>(
+                    st,
+                    ctx,
+                    pos,
+                    new_depth,
+                    -Value::INFINITE,
+                    Value::INFINITE,
+                    ply + 1,
+                    false,
+                    limits,
+                    time_manager,
+                )
+            } else if depth >= 2 && move_count > 1 {
                 inc_stat!(st, lmr_applied);
                 // d = max(1, min(newDepth - r/1024, newDepth + 2)) + PvNode
                 // 内側のmax(1, ...)で1以上が保証され、pv_node(0or1)加算で減ることはない
@@ -3349,20 +3425,10 @@ impl SearchWorker {
 
             pos.undo_move(mv);
 
-            // パス手評価ボーナス: パス手を実行した場合、評価値にボーナスを加算
-            // スケーリングなし（常に設定値の100%を適用）
-            // 負のボーナスも適用（パス抑制用途）
-            // 注意: 詰みスコアには加算しない（mate距離が壊れるため）
-            if mv.is_pass() && !value.is_mate_score() {
-                let bonus = get_scaled_pass_move_bonus(pos.game_ply());
-                if bonus != 0 {
-                    value += Value::new(bonus);
-                }
-            }
-
             if st.abort {
                 return Value::ZERO;
             }
+            value = apply_pass_move_bonus(value, pass_bonus);
 
             // =============================================================
             // スコア更新
@@ -4006,3 +4072,13 @@ impl SearchWorker {
 //    Sync であり、探索中に重みデータが変更されることはない。
 //    各ワーカーが独立した reset() で設定し、探索中は読み取りのみ行う。
 unsafe impl Send for SearchWorker {}
+
+/// 完了した PASS の有限スコアだけに加算し、詰み領域へ入れない。
+#[inline]
+pub(super) fn apply_pass_move_bonus(value: Value, bonus: i32) -> Value {
+    if bonus == 0 || value.is_mate_score() {
+        return value;
+    }
+    let limit = Value::MATE_IN_MAX_PLY.raw() - 1;
+    Value::new(value.raw().saturating_add(bonus).clamp(-limit, limit))
+}

--- a/crates/rshogi-core/src/search/tests/mod.rs
+++ b/crates/rshogi-core/src/search/tests/mod.rs
@@ -8,3 +8,6 @@ mod history_update;
 mod multi_pv;
 mod skill;
 mod time_management;
+
+#[cfg(all(not(feature = "search-no-pass-rules"), not(target_arch = "wasm32")))]
+mod pass_bonus;

--- a/crates/rshogi-core/src/search/tests/pass_bonus.rs
+++ b/crates/rshogi-core/src/search/tests/pass_bonus.rs
@@ -1,0 +1,186 @@
+//! グローバル設定を別プロセスに隔離した PASS ボーナスの実探索テスト。
+use crate::eval::{EvalHash, set_pass_move_bonus};
+use crate::nnue::{
+    AccumulatorStackVariant, halfka_split::HalfKaSplitStack,
+    network_halfka_split::AccumulatorStackHalfKaSplit,
+};
+use crate::position::Position;
+use crate::search::{
+    LimitsType, RootMove, RootMoves, SearchTuneParams, SearchWorker, TimeManagement,
+};
+use crate::tt::TranspositionTable;
+use crate::types::{Move, Value};
+use std::sync::{Arc, atomic::AtomicBool};
+
+fn run_root(
+    sfen: &str,
+    bonus: i32,
+    mode: u8,
+    window: (Value, Value),
+    stop: bool,
+) -> (Value, Value) {
+    set_pass_move_bonus(bonus);
+    let mut pos = Position::new();
+    pos.set_sfen(sfen).unwrap();
+    pos.enable_pass_rights(1, 0);
+    let before = (pos.to_sfen(), pos.key());
+    let limits = LimitsType {
+        depth: 1,
+        ..Default::default()
+    };
+    let mut worker = SearchWorker::new(
+        Arc::new(TranspositionTable::new(1)),
+        Arc::new(EvalHash::new(1)),
+        0,
+        0,
+        SearchTuneParams::default(),
+    );
+    worker.prepare_search(&limits);
+    // 未初期化 HalfKP push の別課題に依存しない有効な storage。
+    worker.state.nnue_stack = AccumulatorStackVariant::HalfKaSplit(HalfKaSplitStack::L256(
+        AccumulatorStackHalfKaSplit::new(),
+    ));
+    worker.state.calls_cnt = 2;
+    worker.state.root_depth = 1;
+    worker.state.root_moves = if mode == 1 || mode == 2 || mode == 4 {
+        let normal = RootMoves::from_legal_moves(&pos, &[])
+            .iter()
+            .find(|rm| !rm.pv[0].is_pass())
+            .unwrap()
+            .pv[0];
+        if mode == 1 {
+            RootMoves::from_vec(vec![RootMove::new(normal), RootMove::new(Move::PASS)])
+        } else {
+            RootMoves::from_vec(vec![RootMove::new(Move::PASS), RootMove::new(normal)])
+        }
+    } else {
+        RootMoves::from_legal_moves(&pos, &[Move::PASS])
+    };
+    assert!(pos.is_legal(Move::PASS));
+    let mut tm =
+        TimeManagement::new(Arc::new(AtomicBool::new(stop)), Arc::new(AtomicBool::new(false)));
+    let value = if mode == 3 {
+        worker.tt.probe(pos.key(), &pos).write(
+            pos.key(),
+            Value::NONE,
+            false,
+            crate::types::Bound::None,
+            0,
+            Move::PASS,
+            Value::NONE,
+            worker.tt.generation(),
+        );
+        worker.search_node_wrapper::<{ crate::search::NodeType::PV as u8 }>(
+            &mut pos, 1, window.0, window.1, 1, false, &limits, &mut tm,
+        )
+    } else if mode == 1 || mode == 4 {
+        worker.search_root_for_pv(&mut pos, 1, window.0, window.1, 1, &limits, &mut tm)
+    } else {
+        worker.search_root(&mut pos, 1, window.0, window.1, &limits, &mut tm)
+    };
+    assert_eq!((pos.to_sfen(), pos.key()), before);
+    match &worker.state.nnue_stack {
+        AccumulatorStackVariant::HalfKaSplit(stack) => assert_eq!(stack.current_index(), 0),
+        _ => unreachable!(),
+    }
+    assert_eq!(worker.state.abort, stop);
+    let rm = worker.state.root_moves.iter().find(|rm| rm.pv[0].is_pass()).unwrap();
+    (value, rm.score)
+}
+
+#[test]
+fn pass_bonus_isolated_regression() {
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "search::tests::pass_bonus::pass_bonus_child",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("RSHOGI_PASS_BONUS_CHILD", "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[ignore = "グローバル設定を隔離する親テスト経由でのみ実行"]
+fn pass_bonus_child() {
+    assert_eq!(std::env::var("RSHOGI_PASS_BONUS_CHILD").as_deref(), Ok("1"));
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(|| {
+            crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+            let full = (-Value::INFINITE, Value::INFINITE);
+            let only_pass = "Kp7/1r7/9/2b6/9/9/9/9/8k b - 1";
+            let mut fixture = Position::new();
+            fixture.set_sfen(only_pass).unwrap();
+            fixture.enable_pass_rights(1, 0);
+            let legal = RootMoves::from_legal_moves(&fixture, &[]);
+            assert_eq!(legal.len(), 1);
+            assert_eq!(legal[0].pv[0], Move::PASS);
+            let base = run_root(only_pass, 0, 0, full, false).0;
+            assert!(!base.is_mate_score());
+            for bonus in [-100, 0, 100] {
+                let expected = base + Value::new(bonus);
+                assert_eq!(run_root(only_pass, bonus, 0, full, false), (expected, expected));
+                if bonus != 0 {
+                    // 真値が fail-low になる窓。未補正の子の fail-high bound を加算してはいけない。
+                    let narrow = (expected + Value::new(1), expected + Value::new(2));
+                    assert_eq!(run_root(only_pass, bonus, 0, narrow, false).0, expected);
+                }
+                assert_eq!(run_root(only_pass, bonus, 0, full, true).0, Value::ZERO);
+            }
+            let mate_sfen = "K8/8r/9/9/9/9/9/9/1r6k b - 1";
+            let mate = run_root(mate_sfen, 0, 0, full, false).0;
+            assert!(mate.is_mate_score());
+            for bonus in [-100, 100] {
+                assert_eq!(run_root(mate_sfen, bonus, 0, full, false).0, mate);
+            }
+            let internal_base = run_root(only_pass, 0, 3, full, false).0;
+            for bonus in [-100, 100] {
+                let expected = internal_base + Value::new(bonus);
+                assert_eq!(run_root(only_pass, bonus, 3, full, false).0, expected);
+                assert_eq!(
+                    run_root(
+                        only_pass,
+                        bonus,
+                        3,
+                        (expected + Value::new(1), expected + Value::new(2)),
+                        false
+                    )
+                    .0,
+                    expected
+                );
+                assert_eq!(run_root(only_pass, bonus, 3, full, true).0, Value::ZERO);
+            }
+            let mixed = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+            let base = run_root(mixed, 0, 1, full, false).0;
+            let normal = run_root(mixed, 0, 4, full, false).0;
+            for bonus in [-100, 0, 100] {
+                let expected = base + Value::new(bonus);
+                assert_eq!(run_root(mixed, bonus, 4, full, false).0, normal);
+                assert_eq!(run_root(mixed, bonus, 2, full, false).0, expected.max(normal));
+                assert_eq!(run_root(mixed, bonus, 1, full, false), (expected, expected));
+                assert_eq!(run_root(mixed, bonus, 0, full, false), (expected, expected));
+            }
+            use crate::search::alpha_beta::apply_pass_move_bonus;
+            for value in [Value::mate_in(1), Value::mated_in(7), Value::NONE] {
+                for bonus in [-100, 100] {
+                    assert_eq!(apply_pass_move_bonus(value, bonus), value);
+                }
+            }
+            for bonus in [i32::MIN, i32::MAX] {
+                let value = apply_pass_move_bonus(Value::new(50), bonus);
+                assert!(!value.is_mate_score());
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}

--- a/crates/rshogi-core/src/search/tests/pass_bonus.rs
+++ b/crates/rshogi-core/src/search/tests/pass_bonus.rs
@@ -60,7 +60,7 @@ fn run_root(
     let mut tm =
         TimeManagement::new(Arc::new(AtomicBool::new(stop)), Arc::new(AtomicBool::new(false)));
     let value = if mode == 3 {
-        worker.tt.probe(pos.key(), &pos).write(
+        assert!(worker.tt.probe(pos.key(), &pos).write(
             pos.key(),
             Value::NONE,
             false,
@@ -69,7 +69,7 @@ fn run_root(
             Move::PASS,
             Value::NONE,
             worker.tt.generation(),
-        );
+        ));
         worker.search_node_wrapper::<{ crate::search::NodeType::PV as u8 }>(
             &mut pos, 1, window.0, window.1, 1, false, &limits, &mut tm,
         )


### PR DESCRIPTION
PassMoveBonus が内部探索の PASS にだけ適用され、root と MultiPV の PASS に反映されていませんでした。3 経路で共通の加算処理を使い、局面・NNUE stack の復元と中断確認の後、完了した通常評価値に設定値を加えます。詰み値は維持し、通常値は詰み領域の手前で飽和させます。

非ゼロ PASS は子を full PV window・未削減の深さで探索します。元の狭窓の fail bound に後から加算すると誤った cutoff が起こるためです。TT による既存の深さ延長は維持します。通常手と bonus=0 は既存の PVS/LMR 経路です。非ゼロ PASS の探索ノード数が増える可能性があり、棋力・NPS の改善は主張しません。

検証:
- PASS 有効ビルドで、sole legal PASS の root/internal、通常手と PASS の MultiPV・順位比較、0/+100/-100、狭窓、実 mate 不変性、子探索停止時の復元と ZERO 伝播を検証。設定変更は別テストプロセスに隔離。
- full-window 分岐を無効化した対照では、真値 -1835・窓 [-1834,-1833] に対して -1808 の誤った fail-high となり、狭窓テストが失敗。最終コードへ復元後は通過。
- PASS 有効 USI、MaterialLevel=1、depth=1 の smoke: bonus 0/+100/-100 で score cp -2150/-2038/-2261、いずれも bestmove pass。設定値は内部単位で、USI cp は歩価値 90 により正規化されます。
- cargo fmt、cargo clippy -j4 --fix --allow-dirty --tests、cargo test -j4、tracked absolute path check、最終 fmt check。
- 独立 Codex reviewer 2 名 APPROVE。

対象: 20260909-code-review-02-search-bec3b988-032631 / T4 (SEARCH-04)。内部 PASS の TT 読込を検証する前提として、#1048 の Position::to_move 特殊値正規化 hunk とその API 説明だけを同内容で含みます。#1048 の他の変更は含めていません。統合時は同じ正規化処理を一度だけ残してください。
