### PR TITLE
fix(tools): plot CSVの入力aliasと途中失敗を保護

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -138,3 +138,5 @@ cargo run -p tools --release --bin benchmark -- --internal
 ## 使用例
 
 より多くのコマンド例は [examples/README.md](examples/README.md) を参照。
+
+- [spsa_stats_to_plot_csv](docs/spsa_stats_to_plot_csv.md) - 入力 alias を拒否し、変換成功時だけ plot CSV を置換

--- a/crates/tools/docs/spsa_stats_to_plot_csv.md
+++ b/crates/tools/docs/spsa_stats_to_plot_csv.md
@@ -1,0 +1,13 @@
+# SPSA 統計を plot CSV へ変換する
+
+```bash
+cargo run --release -p tools --bin spsa_stats_to_plot_csv -- stats.csv --output-csv stats.plot.csv --window 8
+```
+
+入力は seed 統計 CSV または旧 v3 の aggregate 統計 CSV です。`values.csv` や v4 batch 統計への対応を追加する変更ではありません。認識できない header はエラーになります。
+
+`--output-csv` を省略すると入力名に `.plot.csv` を付けます。`--window` は 1 以上で、score_rate の移動平均の幅です（既定 8）。
+
+入力と同じファイルへの出力は、同じパス・hardlink・symlink を含めて拒否します。出力 symlink は別ファイルを指す場合も拒否します。変換中は出力先と同じディレクトリの一時ファイルへ書き、全行の変換と flush が成功したときだけ出力を置き換えます。不正な途中行で失敗しても入力と既存の出力を保持し、一時ファイルを除去します。出力先ディレクトリは事前に用意してください。
+
+出力には勝敗率、score_rate、累積と移動平均、更新量などの列が入ります。既存の集計式と列定義は変更していません。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -92,7 +92,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `generate_net_spsa_params` | LayerStacks `.bin` を走査し、net 重み delta 用 SPSA `.params` を生成（[詳細](generate_net_spsa_params.md)） |
 | `apply_net_spsa_params` | SPSA の net 重み delta を LayerStacks `.bin` へ焼き込み、feature 非依存の読み戻し検証と SHA-256 report を行う（[詳細](apply_net_spsa_params.md)） |
 | `spsa_param_diff` | SPSA .params の最終差分と履歴差分を集計 |
-| `spsa_stats_to_plot_csv` | SPSA 統計を可視化用 CSV に整形（移動平均計算） |
+| `spsa_stats_to_plot_csv` | SPSA 統計を可視化用 CSV に整形。入力 alias を拒否し成功時だけ置換（[詳細](spsa_stats_to_plot_csv.md)） |
 | `params_to_shogitest_options` | SPSA .params を shogitest 互換オプション文字列に変換 |
 
 ## 外部連携・ログ解析

--- a/crates/tools/src/bin/spsa_stats_to_plot_csv.rs
+++ b/crates/tools/src/bin/spsa_stats_to_plot_csv.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use tools::output_path::ensure_safe_output_path;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
@@ -64,6 +66,7 @@ fn main() -> Result<()> {
         .clone()
         .unwrap_or_else(|| PathBuf::from(format!("{}.plot.csv", cli.input_csv.display())));
 
+    ensure_safe_output_path(&output_csv, &cli.input_csv)?;
     let src = File::open(&cli.input_csv)
         .with_context(|| format!("failed to open {}", cli.input_csv.display()))?;
     let mut reader = BufReader::new(src);
@@ -85,9 +88,15 @@ fn main() -> Result<()> {
     let mode = detect_mode(&headers)?;
     let index = build_index(&headers);
 
-    let dst = File::create(&output_csv)
-        .with_context(|| format!("failed to create {}", output_csv.display()))?;
-    let mut writer = BufWriter::new(dst);
+    let parent = output_csv
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let mut staged = tempfile::Builder::new()
+        .prefix(".spsa_plot_")
+        .tempfile_in(parent)
+        .with_context(|| format!("failed to stage {}", output_csv.display()))?;
+    let mut writer = BufWriter::new(staged.as_file_mut());
     let output_headers = [
         "iteration",
         "mode",
@@ -188,6 +197,11 @@ fn main() -> Result<()> {
     }
 
     writer.flush()?;
+    drop(writer);
+    ensure_safe_output_path(&output_csv, &cli.input_csv)?;
+    staged
+        .persist(&output_csv)
+        .with_context(|| format!("failed to publish {}", output_csv.display()))?;
     Ok(())
 }
 
@@ -364,7 +378,7 @@ fn row_values_aggregate(row: &CsvRow<'_>) -> Result<RowValues> {
     })
 }
 
-fn write_csv_row(writer: &mut BufWriter<File>, row: &[impl AsRef<str>]) -> Result<()> {
+fn write_csv_row(writer: &mut impl Write, row: &[impl AsRef<str>]) -> Result<()> {
     for (idx, value) in row.iter().enumerate() {
         if idx > 0 {
             writer.write_all(b",")?;
@@ -375,7 +389,7 @@ fn write_csv_row(writer: &mut BufWriter<File>, row: &[impl AsRef<str>]) -> Resul
     Ok(())
 }
 
-fn write_csv_value(writer: &mut BufWriter<File>, value: &str) -> Result<()> {
+fn write_csv_value(writer: &mut impl Write, value: &str) -> Result<()> {
     let needs_quote = value.contains(',') || value.contains('"') || value.contains('\n');
     if !needs_quote {
         writer.write_all(value.as_bytes())?;

--- a/crates/tools/tests/spsa_plot_output.rs
+++ b/crates/tools/tests/spsa_plot_output.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+use std::process::Command;
+
+const HEADER: &str = "iteration,games,plus_wins,minus_wins,draws,step_sum,grad_scale,a_t,c_t,avg_abs_shift,avg_abs_update,max_abs_update,total_games\n";
+const ROW: &str = "1,2,1,0,1,1,0.5,1,1,0.1,0.2,0.3,2\n";
+
+fn convert(input: &Path, output: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_spsa_stats_to_plot_csv"))
+        .arg(input)
+        .arg("--output-csv")
+        .arg(output)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn aliases_preserve_input_and_fail_before_conversion() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("stats.csv");
+    let original = format!("{HEADER}{}", ROW.repeat(1000));
+    std::fs::write(&input, &original).unwrap();
+    assert!(!convert(&input, &input).status.success());
+    let hard = dir.path().join("hard.csv");
+    std::fs::hard_link(&input, &hard).unwrap();
+    assert!(!convert(&input, &hard).status.success());
+    #[cfg(unix)]
+    {
+        let link = dir.path().join("link.csv");
+        std::os::unix::fs::symlink(&input, &link).unwrap();
+        assert!(!convert(&input, &link).status.success());
+    }
+    assert_eq!(std::fs::read_to_string(&input).unwrap(), original);
+}
+
+#[test]
+fn only_successful_conversion_replaces_existing_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("stats.csv");
+    let output = dir.path().join("plot.csv");
+    std::fs::write(&output, "previous output").unwrap();
+    std::fs::write(&input, format!("{HEADER}{ROW}broken,row\n")).unwrap();
+    assert!(!convert(&input, &output).status.success());
+    assert_eq!(std::fs::read_to_string(&output).unwrap(), "previous output");
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+    std::fs::write(&input, format!("{HEADER}{ROW}")).unwrap();
+    let result = convert(&input, &output);
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    let data = std::fs::read_to_string(&output).unwrap();
+    assert_eq!(data.lines().count(), 2);
+    assert!(data.starts_with("iteration,mode,"));
+    assert_eq!(std::fs::read_to_string(&input).unwrap(), format!("{HEADER}{ROW}"));
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+}


### PR DESCRIPTION
## 変更

spsa_stats_to_plot_csv に入力と同じファイルを出力先として渡すと、変換途中で入力が切り詰められていました。共通の出力パス検査で同一パス・hardlink・symlink を拒否します。

出力は同じディレクトリの一時ファイルに書き、全行の変換と flush が成功したときだけ置き換えます。途中の不正行では入力と既存出力を保持します。集計式や入力形式の対応範囲は変更しません。F04 対応です。

## 検証

- 実 CLI で同一パス / hardlink / symlink の入力保持（1000行fixture）
- 途中不正行で既存出力が不変、一時ファイルの残存なし
- 正常変換で出力置換、入力不変
- cargo fmt / clippy --fix --allow-dirty --tests / cargo test / tracked 絶対パス検査
- 2 独立 Codex レビュー APPROVE

過去ファイルの復旧や v4 CSV 対応を追加する変更ではありません。
