### PR TITLE
chore: 参照されない履歴チューニング定数を削除しツール一覧の説明を整理する

### DIFF
--- a/crates/rshogi-core/src/search/history.rs
+++ b/crates/rshogi-core/src/search/history.rs
@@ -69,45 +69,6 @@ const PIECE_TYPE_NUM: usize = PieceType::NUM + 1; // None含む
 const PIECE_NUM: usize = Piece::NUM; // NONE含む
 
 // =============================================================================
-// 定数
-// =============================================================================
-
-/// 互換用の旧 TTMoveHistory ボーナス定数。
-/// 実探索の更新は `SearchTuneParams::tt_move_history_bonus` を使う。
-pub const TT_MOVE_HISTORY_BONUS: i32 = 811;
-
-/// 互換用の旧 TTMoveHistory ペナルティ定数。
-/// 実探索の更新は `SearchTuneParams::tt_move_history_malus` を使う。
-pub const TT_MOVE_HISTORY_MALUS: i32 = -848;
-
-/// ContinuationHistory更新の重み [(ply_back, weight)]
-///
-/// 1,2,3,4,5,6手前の指し手と現在の指し手のペアを更新。
-/// 王手中は1,2手前のみ更新。
-pub const CONTINUATION_HISTORY_WEIGHTS: [(usize, i32); 6] =
-    [(1, 1157), (2, 648), (3, 288), (4, 576), (5, 140), (6, 441)];
-
-/// update_quiet_histories用のlowPlyHistory倍率
-pub const LOW_PLY_HISTORY_MULTIPLIER: i32 = 761;
-pub const LOW_PLY_HISTORY_OFFSET: i32 = 0;
-
-/// update_quiet_histories用のcontinuationHistory倍率（正負共通）
-pub const CONTINUATION_HISTORY_MULTIPLIER: i32 = 955;
-
-/// update_quiet_histories用のpawnHistory倍率（正のボーナス時）
-pub const PAWN_HISTORY_POS_MULTIPLIER: i32 = 850;
-/// update_quiet_histories用のpawnHistory倍率（負のボーナス時）
-pub const PAWN_HISTORY_NEG_MULTIPLIER: i32 = 550;
-
-/// ContinuationHistory近接ply（1,2手前）へのオフセット
-/// update_continuation_histories で (bonus * weight / 1024) + 88 * (i < 2)
-pub const CONTINUATION_HISTORY_NEAR_PLY_OFFSET: i32 = 88;
-
-/// Prior Capture Countermove Bonus（fail low時の前の捕獲手へのボーナス）
-///
-pub const PRIOR_CAPTURE_COUNTERMOVE_BONUS: i32 = 964;
-
-// =============================================================================
 // StatsEntry
 // =============================================================================
 

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -56,7 +56,7 @@
 
 | ツール | 説明 |
 |--------|------|
-| `benchmark` | USI の評価ハッシュ設定・受信期限に対応。 エンジン性能ベンチマーク |
+| `benchmark` | エンジン性能ベンチマーク。USI の評価ハッシュ設定と受信期限に対応（[詳細](docs/benchmark.md)） |
 | `bench_nnue_eval` | NNUE の固定局面 eval-only と巡回局面 refresh + eval を分けて計測（[詳細](docs/bench_nnue_eval.md)） |
 | `compare_nodes` | 2つの USI エンジン間で探索ノード数を深度別に比較。エンジン別の任意ノード上限を併用可能（[詳細](docs/compare_nodes.md)） |
 | `compare_eval_nnue` | NNUE評価値の比較 |
@@ -117,10 +117,10 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価または hcpe export → yardstick で採点
 - [nyugyoku_metrics](docs/nyugyoku_metrics.md) - 終局 CSA から宣言ルール距離ペアと探索読み切り詰み距離を抽出し、NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
-- [SPSA の既定値生成](docs/spsa_runbook.md) - 無指定の探索・USI 宣言と共通の値から `.params` を生成
-- [spsa](docs/spsa_runbook.md#14-engine-プール再試行停止) - regex 対象外の有効な基準値も両 engine へ適用。有限な schedule を事前検査。永続 engine プールで batch チューニング。`--engine-retries` / `--nodes-timeout-ms` による障害再試行と探索期限。初期化の最終失敗・panic は engine 破棄前に停止通知。watchdog は勝敗に使わず、stdin write 停滞は停止保証の対象外。
+- [generate_spsa_params](docs/spsa_runbook.md) - 無指定の探索・USI 宣言と共通の既定値から SPSA 用 `.params` を生成
+- [spsa](docs/spsa_runbook.md#14-engine-プール再試行停止) - 永続 engine プールで batch チューニング。開始前に schedule の有限性を検査し、regex 対象外の項目も基準値を両 engine へ適用。`--engine-retries` / `--nodes-timeout-ms` による障害再試行と探索期限。初期化の最終失敗・panic は engine 破棄前に停止通知。watchdog は勝敗に使わず、stdin write 停滞は停止保証の対象外。
 - [generate_net_spsa_params](docs/generate_net_spsa_params.md) - LayerStacks `.bin` から net 重み delta 用 SPSA `.params` を生成
-- [apply_net_spsa_params](docs/apply_net_spsa_params.md) - 重複行を拒否。 net 重み SPSA の確定 delta を LayerStacks `.bin` へ焼き込み、feature 非依存で読み戻し検証する
+- [apply_net_spsa_params](docs/apply_net_spsa_params.md) - net 重み SPSA の確定 delta を LayerStacks `.bin` へ焼き込み、feature 非依存で読み戻し検証する。重複行は拒否する
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム / score sidecar（`--out-scores`、dlshogi ONNX と NNUE 静的評価）対応。LayerStacks routing は格納 bucket 数との不一致を拒否し、旧世代 net のみ `--allow-routing-buckets-mismatch` で明示許可）
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
 - [psv_dual_label](docs/psv_dual_label.md) - 通常 PSV の score 退避、dual-label PSV の生成・sidecar 抽出・fail-closed 検証

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -21,7 +21,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `benchmark` | USI の評価ハッシュ設定・受信期限に対応。 YaneuraOu bench 互換の標準ベンチマーク。マルチスレッド対応 |
+| `benchmark` | YaneuraOu bench 互換の標準ベンチマーク。マルチスレッド対応。USI の評価ハッシュ設定と受信期限に対応 |
 | `bench_nnue_eval` | NNUE の固定局面 eval-only と巡回局面 refresh + eval の ns/op。LayerStacks 専用モードは bucket 分布も出力（[詳細](bench_nnue_eval.md)） |
 | `search_only_ab` | search-only A/B ベンチマーク。起動・ロード時間を除外して cycles/node, instructions/node を正確計測。Linux は `perf stat --control`、Windows は ETW NT Kernel Logger の PMC counting（要管理者権限、Hyper-V/VBS 共存可）。CLI 差異は `--perf-events`(Linux) ↔ `--pmc-sources`(Windows) の置き換えと、Windows での `--cpus` shard 並列未対応の 2 点。JSON レポートは `samples` / `summary` が両 OS でスキーマ互換（`cli` ブロックのみ `perf_events` / `pmc_sources` のフィールド名差があり非互換） |
 | `eval_sfens` | SFEN 局面を LayerStacks NNUE で静的評価（`score` は歩=90 の内部スケール、`score_cp` は cp） |
@@ -87,7 +87,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `spsa` | regex 対象外の有効な基準値も両 engine へ適用。schedule の有限性を事前検査。[SPSA チューナー](spsa_runbook.md#14-engine-プール再試行停止)。永続 engine プール、`--engine-retries` / `--nodes-timeout-ms`。初期化の最終失敗・panic は engine 破棄前に停止通知。watchdog は勝敗に使わず、stdin write 停滞は停止保証対象外。対局履歴をエンジンに送信し、千日手を自動終局。paired antithetic + stochastic rounding + 1 batch = 1 update のスケジュールで対局を回す。複数 seed の探索は `--seed` を変えた独立 run dir を別プロセスで並列実行する |
+| `spsa` | [SPSA チューナー](spsa_runbook.md#14-engine-プール再試行停止)。永続 engine プール、`--engine-retries` / `--nodes-timeout-ms`。初期化の最終失敗・panic は engine 破棄前に停止通知。watchdog は勝敗に使わず、stdin write 停滞は停止保証対象外。対局履歴をエンジンに送信し、千日手を自動終局。paired antithetic + stochastic rounding + 1 batch = 1 update のスケジュールで対局を回す。開始前に schedule の有限性を検査し、regex 対象外の項目も基準値を両 engine へ適用する。複数 seed の探索は `--seed` を変えた独立 run dir を別プロセスで並列実行する |
 | `generate_spsa_params` | 実エンジンと共通の既定値から SPSA 用 .params ファイルを生成 |
 | `generate_net_spsa_params` | LayerStacks `.bin` を走査し、net 重み delta 用 SPSA `.params` を生成（[詳細](generate_net_spsa_params.md)） |
 | `apply_net_spsa_params` | 重複係数を拒否し、SPSA の net 重み delta を LayerStacks `.bin` へ焼き込み、feature 非依存の読み戻し検証と SHA-256 report を行う（[詳細](apply_net_spsa_params.md)） |


### PR DESCRIPTION
## 変更

### 参照されない `pub const` の削除 (`crates/rshogi-core/src/search/history.rs`)

「定数」ブロックの 10 個は実探索・テストのいずれからも参照されておらず、`SearchTuneParams` が唯一の正本になっています。`pub` のため `dead_code` 警告も出ず、誤った値を正と読む材料が残っていました。

| 削除した定数 | 値 | 実探索が使う値 |
|---|---|---|
| `TT_MOVE_HISTORY_BONUS` | 811 | `tt_move_history_bonus` = **809** |
| `TT_MOVE_HISTORY_MALUS` | -848 | `tt_move_history_malus` = **-865** |
| `CONTINUATION_HISTORY_WEIGHTS` | 1157/648/288/576/140/441 | `continuation_history_weight_1..6` (同値) |
| `LOW_PLY_HISTORY_MULTIPLIER` / `_OFFSET` | 761 / 0 | 同名フィールド (同値) |
| `CONTINUATION_HISTORY_MULTIPLIER` | 955 | 同名フィールド (同値) |
| `PAWN_HISTORY_POS_MULTIPLIER` / `_NEG_` | 850 / 550 | 同名フィールド (同値) |
| `CONTINUATION_HISTORY_NEAR_PLY_OFFSET` | 88 | 同名フィールド (同値) |
| `PRIOR_CAPTURE_COUNTERMOVE_BONUS` | 964 | 同名フィールド (同値) |

値が食い違うのは `tt_move_history` の 2 件だけで、残る 8 件は同値の重複定義でした。

サイズ・上限・初期値 (`PAWN_HISTORY_SIZE`, `CORRECTION_HISTORY_SIZE`, `CORRECTION_HISTORY_LIMIT`, `LOW_PLY_HISTORY_SIZE`, `FROM_TO_SIZE`, `CONTINUATION_HISTORY_INIT`) は実際に使われているため残しています。

**探索の挙動は変わりません。** 削除対象はいずれも参照ゼロで、実探索は従来どおり `SearchTuneParams` を読みます。

### ツール一覧表の整理 (`crates/tools/README.md`, `docs/tools-reference.md`)

一覧表は「そのツールが何か」を書く場所ですが、個別機能の追記が説明の先頭に置かれ、主述が逆転していました。機能は本文へ畳み、項目名を揃えています。

- `benchmark` — 「USI の評価ハッシュ設定・受信期限に対応。 エンジン性能ベンチマーク」→ 主述を戻し、二重スペースを除去
- `spsa` — 冒頭に連結していた 2 つの追記を本文へ移動
- `apply_net_spsa_params` — 冒頭の「重複行を拒否。 」を末尾へ、二重スペースを除去
- `SPSA の既定値生成` — 散文タイトルだった項目名を `generate_spsa_params` に統一

## 検証

- `cargo fmt` / `cargo clippy --fix --allow-dirty --tests` (警告 0) / `cargo test` / tracked 絶対パス検査
- 削除した 10 定数について、`crates/` 全体の `*.rs` から参照ゼロを確認。`.md` / `.toml` の一致は SPSA オプション名 (`SPSA_LOW_PLY_HISTORY_MULTIPLIER` 等) であって Rust 定数ではないことを確認
- 整理後の README / tools-reference に、説明冒頭の実装追記と二重スペースが残っていないことを再検査

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McET8vFZtu9Em9Hh3tnKWY