### PR TITLE
fix(search): TT fixture の write 戻り値を明示的に捨てる

### DIFF
--- a/crates/rshogi-core/src/search/tests/history_update.rs
+++ b/crates/rshogi-core/src/search/tests/history_update.rs
@@ -67,7 +67,7 @@ fn observe_completed_node(
         let check = child.gives_check(mv);
         child.do_move(mv, check);
         let score = -(alpha.raw() + if mv == best { 100 } else { -100 });
-        worker.tt.probe(child.key(), &child).write(
+        let _ = worker.tt.probe(child.key(), &child).write(
             child.key(),
             Value::new(score),
             false,
@@ -78,7 +78,7 @@ fn observe_completed_node(
             worker.tt.generation(),
         );
     }
-    worker.tt.probe(pos.key(), &pos).write(
+    let _ = worker.tt.probe(pos.key(), &pos).write(
         pos.key(),
         Value::NONE,
         false,


### PR DESCRIPTION
## 問題

main (`dceca63a`) で `cargo clippy --tests -D warnings` が失敗しています。

```
error: unused return value of `tt::table::ProbeResult::<'_>::write` that must be used
  --> crates/rshogi-core/src/search/tests/history_update.rs:70:9
  --> crates/rshogi-core/src/search/tests/history_update.rs:81:5
```

#1044 が `ProbeResult::write` に `#[must_use]` を付け、#1064 が追加した TT fixture の準備コードが戻り値を捨てているためです。両者はテキスト衝突しないため個別にはマージでき、main で組み合わさって初めて失敗する意味的衝突でした。

main を取り込む PR はすべてこの Clippy で落ちます。

## 変更

`write` の doc が定める契約 — 「戻り値を捨てる呼び出しは、格納の成否に依存する記録 (統計・トレース) を伴わないことを `let _ =` で明示する」 — に従い、2 箇所へ `let _ =` を付けます。どちらも TT fixture の準備で、格納の成否を後続で使いません。`write` は「競合による省略はなく常に true」と doc に明記されており、捨てて失う情報もありません。

テストの意図・探索の挙動は変わりません。

## 検証

- `cargo clippy --tests` (警告 0) / `cargo clippy --workspace --all-targets -- -D warnings` (CI と同条件、警告 0)
- `cargo fmt --check` / tracked 絶対パス検査
- `search::tests::history_update` の 5 テスト、および workspace 全体のテストが pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McET8vFZtu9Em9Hh3tnKWY