### PR TITLE
fix(search): ponder中はノード予算で停止しない

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1076,8 +1076,8 @@ impl SearchWorker {
             return true;
         }
 
-        // ノード数制限チェック
-        if limits.nodes > 0 && self.state.nodes >= limits.nodes {
+        // ponder 中は予算を使い切っても、GUI の通知まで探索を継続する。
+        if limits.nodes > 0 && !time_manager.is_pondering() && self.state.nodes >= limits.nodes {
             #[cfg(debug_assertions)]
             eprintln!(
                 "check_abort: node limit reached nodes={} limit={}",

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1589,7 +1589,9 @@ where
                 // （check_abort は頻度制御で呼び出されるため、abort フラグが
                 //   立っていないまま search_root が返ることがある）
                 if worker.state.abort
-                    || (limits.nodes > 0 && worker.state.nodes >= limits.nodes)
+                    || (limits.nodes > 0
+                        && !time_manager.is_pondering()
+                        && worker.state.nodes >= limits.nodes)
                     || time_manager.stop_requested()
                 {
                     worker.state.abort = true;

--- a/crates/rshogi-core/src/search/search_helpers.rs
+++ b/crates/rshogi-core/src/search/search_helpers.rs
@@ -59,8 +59,8 @@ pub(super) fn check_abort(
         return true;
     }
 
-    // ノード数制限チェック
-    if limits.nodes > 0 && st.nodes >= limits.nodes {
+    // ponder 中は予算を使い切っても、GUI の通知まで探索を継続する。
+    if limits.nodes > 0 && !time_manager.is_pondering() && st.nodes >= limits.nodes {
         #[cfg(debug_assertions)]
         eprintln!("check_abort: node limit reached nodes={} limit={}", st.nodes, limits.nodes);
         st.abort = true;

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -11,6 +11,70 @@ use crate::search::{LimitsType, SearchTuneParams};
 use crate::tt::TranspositionTable;
 
 #[test]
+fn test_node_budget_respects_ponder_and_external_stop() {
+    use crate::search::{TimeManagement, alpha_beta::SearchState};
+    use crate::types::Color;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    for split_path in [false, true] {
+        for thread_id in [0, 1] {
+            for mode in 0..3 {
+                let stop = Arc::new(AtomicBool::new(false));
+                let hit = Arc::new(AtomicBool::new(false));
+                let limits = LimitsType {
+                    nodes: 100,
+                    ponder: mode != 0,
+                    ..LimitsType::new()
+                };
+                let mut tm = TimeManagement::new(Arc::clone(&stop), Arc::clone(&hit));
+                tm.init(&limits, Color::Black, 0, 256);
+                let mut worker = SearchWorker::new(
+                    Arc::new(TranspositionTable::new(1)),
+                    Arc::new(EvalHash::new(1)),
+                    0,
+                    thread_id,
+                    SearchTuneParams::default(),
+                );
+                let mut state = SearchState::new();
+                state.nodes = limits.nodes;
+                worker.state.nodes = limits.nodes;
+                let mut check = |tm: &mut TimeManagement| {
+                    if split_path {
+                        state.calls_cnt = 1;
+                        super::super::search_helpers::check_abort(
+                            &mut state,
+                            &worker.create_context(),
+                            &limits,
+                            tm,
+                        )
+                    } else {
+                        worker.state.calls_cnt = 1;
+                        worker.check_abort(&limits, tm)
+                    }
+                };
+                if mode == 0 {
+                    assert!(check(&mut tm), "通常探索はノード上限で停止する");
+                    continue;
+                }
+                assert!(!check(&mut tm), "ponder 中はノード上限で停止しない");
+                if mode == 1 {
+                    hit.store(true, Ordering::Relaxed);
+                    assert!(!check(&mut tm));
+                    if thread_id == 0 {
+                        assert!(!tm.is_pondering());
+                        assert!(check(&mut tm), "hit 後は既に消費したノード予算で停止する");
+                        continue;
+                    }
+                    assert!(hit.load(Ordering::Relaxed), "helper は main の通知を消費しない");
+                }
+                stop.store(true, Ordering::Relaxed);
+                assert!(check(&mut tm), "ponder 中も外部 stop は有効");
+            }
+        }
+    }
+}
+
+#[test]
 fn test_reduction_values() {
     // reduction(true, 10, 5) などが正の値を返すことを確認
     let tune = SearchTuneParams::default();

--- a/crates/rshogi-usi/tests/ponder_nodes.rs
+++ b/crates/rshogi-usi/tests/ponder_nodes.rs
@@ -1,0 +1,76 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+#[test]
+fn node_limited_ponder_waits_for_hit_or_stop() {
+    for threads in [1, 4] {
+        for release in ["ponderhit", "stop"] {
+            let mut child = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+            let stdout = child.stdout.take().unwrap();
+            let (sender, receiver) = mpsc::channel();
+            let reader = std::thread::spawn(move || {
+                for line in BufReader::new(stdout).lines() {
+                    if sender.send(line.unwrap()).is_err() {
+                        break;
+                    }
+                }
+            });
+            let result = (|| -> Result<(), String> {
+                let wait_for = |prefix: &str, duration: Duration| -> Result<String, String> {
+                    let deadline = Instant::now() + duration;
+                    loop {
+                        let line = receiver
+                            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                            .map_err(|err| err.to_string())?;
+                        if line.starts_with(prefix) {
+                            return Ok(line);
+                        }
+                        if line.starts_with("bestmove ") {
+                            return Err(format!("early {line}"));
+                        }
+                    }
+                };
+                writeln!(child.stdin.as_mut().unwrap(), "usi\nsetoption name MaterialLevel value 9\nsetoption name Threads value {threads}\nsetoption name USI_Hash value 16\nisready").map_err(|err| err.to_string())?;
+                wait_for("readyok", Duration::from_secs(10))?;
+                writeln!(child.stdin.as_mut().unwrap(), "position startpos\ngo ponder nodes 100")
+                    .map_err(|err| err.to_string())?;
+                // 探索が起動したことを確認してから無出力期間を検査する。
+                wait_for("info depth ", Duration::from_secs(10))?;
+                let deadline = Instant::now() + Duration::from_millis(300);
+                loop {
+                    match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                    {
+                        Ok(line) if line.starts_with("bestmove ") => {
+                            return Err(format!("before {release}: {line}"));
+                        }
+                        Ok(_) => {}
+                        Err(mpsc::RecvTimeoutError::Timeout) => break,
+                        Err(err) => return Err(err.to_string()),
+                    }
+                }
+                writeln!(child.stdin.as_mut().unwrap(), "{release}")
+                    .map_err(|err| err.to_string())?;
+                let bestmove = wait_for("bestmove ", Duration::from_secs(3))?;
+                if bestmove.starts_with("bestmove resign") {
+                    return Err(bestmove);
+                }
+                Ok(())
+            })();
+            if result.is_ok() {
+                writeln!(child.stdin.as_mut().unwrap(), "quit").unwrap();
+            } else {
+                let _ = child.kill();
+            }
+            let status = child.wait().unwrap();
+            reader.join().unwrap();
+            result.unwrap_or_else(|err| panic!("threads={threads} release={release}: {err}"));
+            assert!(status.success());
+        }
+    }
+}


### PR DESCRIPTION
`go ponder nodes 100` がノード上限で探索を終了し、ponderhit / stop より前に bestmove を返す問題を修正します。

2系統のノード内停止判定と、ルート探索後の停止判定に ponder ガードを加えます。ponder 中はノード上限で停止せず、hit 後は先読み中に探索したノードも含む既存の予算で停止します。外部 stop は引き続き有効です。通常の `go nodes` とノード数の集計方式は変更しません。

Stockfish でも ponder 中はノード予算による停止を抑えています: [search.cpp](https://github.com/official-stockfish/Stockfish/blob/59aae690f91d6f69aac194f447d84b4a2c3be778/src/search.cpp#L2131)。

検証:

- 両ノード内判定について main / helper、通常 nodes、ponderhit、外部 stop を単体テストで検証
- 実 USI は Threads=1・4 × ponderhit / stop。初回 info 後300msの無出力と通知後の bestmove を検証
- ノード修正を含まないエンジンでは、同じ回帰テストが hit 前の bestmove を検出して失敗
- 固定時間 ponder の修正 #1049 と組み合わせた全 workspace cargo test が成功
- fmt、Clippy、tracked絶対パス検査、独立ローカルレビュー APPROVE

棋力評価・NPS計測・探索木一致検証は実施していません。通常時計の配分式は変更しません。
