### PR TITLE
fix(search): 合法手ゼロを敗北とし中断時に完了結果を返す

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -3441,7 +3441,7 @@ impl SearchWorker {
         }
 
         // =================================================================
-        // 詰み/ステイルメイト判定 + History更新
+        // 合法手なしの敗北判定 + History更新
         // =================================================================
         // if-else チェイン
         // moveCount == 0: bestValue を設定して関数末尾までフォールスルー
@@ -3450,14 +3450,11 @@ impl SearchWorker {
         // else if: prior countermove bonus
         if move_count == 0 {
             // excludedMoveがある場合は単にalphaを返す（詰みとは判定しない）
-            // 合法手なし（将棋では in_check == true なら詰み）
+            // 将棋では王手の有無にかかわらず合法手なしは負け。
             best_value = if excluded_move.is_some() {
                 alpha
-            } else if in_check {
-                Value::mated_in(ply)
             } else {
-                // ステイルメイト（将棋では通常発生しないがパスがない場合）
-                Value::ZERO
+                Value::mated_in(ply)
             };
         } else if best_move.is_some() && !best_move.is_pass() {
             // =================================================================

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -576,6 +576,7 @@ struct BestThreadResult {
 
 fn collect_best_thread_result(
     worker: &SearchWorker,
+    pos: &Position,
     limits: &LimitsType,
     skill_enabled: bool,
     skill: &mut Skill,
@@ -595,7 +596,12 @@ fn collect_best_thread_result(
         return BestThreadResult {
             best_move: Move::NONE,
             ponder_move: Move::NONE,
-            score: Value::ZERO,
+            // searchmoves による候補ゼロは、実際の合法手ゼロと区別する。
+            score: if super::RootMoves::from_legal_moves(pos, &[]).is_empty() {
+                Value::mated_in(0)
+            } else {
+                Value::ZERO
+            },
             completed_depth,
             sel_depth: worker.state.sel_depth,
             nodes,
@@ -1116,7 +1122,7 @@ impl Search {
                 .worker
                 .as_ref()
                 .expect("worker should be initialized by search_with_callback");
-            collect_best_thread_result(worker, &limits, skill_enabled, &mut skill)
+            collect_best_thread_result(worker, pos, &limits, skill_enabled, &mut skill)
         } else {
             // Native: Use helper_threads() to access Thread objects directly
             #[cfg(not(target_arch = "wasm32"))]
@@ -1125,7 +1131,13 @@ impl Search {
                 for thread in self.thread_pool.helper_threads() {
                     if thread.id() == best_thread_id {
                         result = Some(thread.with_worker(|worker: &mut SearchWorker| {
-                            collect_best_thread_result(worker, &limits, skill_enabled, &mut skill)
+                            collect_best_thread_result(
+                                worker,
+                                pos,
+                                &limits,
+                                skill_enabled,
+                                &mut skill,
+                            )
                         }));
                         break;
                     }
@@ -1182,7 +1194,7 @@ impl Search {
                     .worker
                     .as_ref()
                     .expect("worker should be initialized by search_with_callback");
-                collect_best_thread_result(worker, &limits, skill_enabled, &mut skill)
+                collect_best_thread_result(worker, pos, &limits, skill_enabled, &mut skill)
             })
         };
 
@@ -1457,10 +1469,8 @@ where
     }
     effective_multi_pv = effective_multi_pv.min(worker.state.root_moves.len());
 
-    // 中断時にPVを巻き戻すための保持
-    let mut last_best_pv = vec![Move::NONE];
-    let mut last_best_score = Value::new(-Value::INFINITE.raw());
-    let mut last_best_move_depth = 0;
+    // MultiPV・skill・helper の結果も完了した反復の score/PV/順位で返す。
+    let mut completed_root_moves = super::RootMoves::new();
 
     // ヘルパー用のローカル search_again_counter
     let mut local_search_again_counter: i32 = 0;
@@ -1701,6 +1711,8 @@ where
                 rm.previous_score = rm.score;
             }
 
+            completed_root_moves.clone_from(&worker.state.root_moves);
+
             let best_move_changes = worker.state.best_move_changes;
             worker.state.best_move_changes = 0.0;
 
@@ -1801,15 +1813,6 @@ where
                 on_progress(worker.state.nodes, best_move_changes);
             }
 
-            // PVが変わったときのみ last_best_* を更新
-            if !worker.state.root_moves[0].pv.is_empty()
-                && worker.state.root_moves[0].pv[0] != last_best_pv[0]
-            {
-                last_best_pv = worker.state.root_moves[0].pv.clone();
-                last_best_score = worker.state.root_moves[0].score;
-                last_best_move_depth = depth;
-            }
-
             // 詰みスコアが見つかっていたら早期終了
             // ponder中は stop/ponderhit を待つ必要があるためスキップ（USI仕様準拠）
             if effective_multi_pv == 1
@@ -1841,20 +1844,9 @@ where
     // 反復深化が自然終了した場合も、終局分岐と同じ通知待機を通る。
     wait_for_search_release(worker.state.abort, limits, time_manager, main_state.as_deref());
 
-    // 中断した探索で信頼できないPVになった場合のフォールバック
-    if worker.state.abort
-        && !worker.state.root_moves.is_empty()
-        && worker.state.root_moves[0].score.is_loss()
-    {
-        let head = last_best_pv.first().copied().unwrap_or(Move::NONE);
-        if head != Move::NONE
-            && let Some(idx) = worker.state.root_moves.find(head)
-        {
-            worker.state.root_moves.move_to_front(idx);
-            worker.state.root_moves[0].pv = last_best_pv;
-            worker.state.root_moves[0].score = last_best_score;
-            worker.state.completed_depth = last_best_move_depth;
-        }
+    // 中断した反復の番兵や bound を、完了深さの結果と混ぜない。
+    if worker.state.abort && !completed_root_moves.is_empty() {
+        worker.state.root_moves = completed_root_moves;
     }
 
     effective_multi_pv

--- a/crates/rshogi-core/src/search/tests/mod.rs
+++ b/crates/rshogi-core/src/search/tests/mod.rs
@@ -11,3 +11,5 @@ mod time_management;
 
 mod mate1_tt;
 mod probcut_abort;
+
+mod terminal_result;

--- a/crates/rshogi-core/src/search/tests/terminal_result.rs
+++ b/crates/rshogi-core/src/search/tests/terminal_result.rs
@@ -1,0 +1,164 @@
+//! 合法手なしの敗北と、中断時の完了結果の整合性。
+use std::sync::{Arc, atomic::AtomicBool};
+
+use crate::eval::EvalHash;
+use crate::position::Position;
+use crate::search::alpha_beta::SearchWorker;
+use crate::search::types::NodeType;
+use crate::search::{LimitsType, RootMoves, Search, SearchInfo, SearchTuneParams, TimeManagement};
+use crate::tt::TranspositionTable;
+use crate::types::{Move, Value};
+
+fn on_large_stack(f: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(f)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+#[test]
+fn terminal_without_check_is_loss() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        let mut pos = Position::new();
+        pos.set_sfen("K8/8r/9/9/9/9/9/9/1r6k b - 1").unwrap();
+        assert!(!pos.in_check());
+        assert!(RootMoves::from_legal_moves(&pos, &[]).is_empty());
+        let limits = LimitsType {
+            depth: 1,
+            ..Default::default()
+        };
+        let mut search = Search::new(1);
+        let result = search.go(&mut pos, limits.clone(), None::<fn(&SearchInfo)>);
+        assert_eq!(result.best_move, Move::NONE);
+        assert_eq!(result.score, Value::mated_in(0));
+
+        let mut worker = SearchWorker::new(
+            Arc::new(TranspositionTable::new(1)),
+            Arc::new(EvalHash::new(1)),
+            0,
+            0,
+            SearchTuneParams::default(),
+        );
+        worker.prepare_search(&limits);
+        let mut tm =
+            TimeManagement::new(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
+        let score = worker.search_node_wrapper::<{ NodeType::PV as u8 }>(
+            &mut pos,
+            1,
+            -Value::INFINITE,
+            Value::INFINITE,
+            1,
+            false,
+            &limits,
+            &mut tm,
+        );
+        assert_eq!(score, Value::mated_in(1));
+    });
+}
+
+#[test]
+fn terminal_searchmoves_empty_is_not_loss() {
+    on_large_stack(|| {
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let mut search = Search::new(1);
+        let result = search.go(
+            &mut pos,
+            LimitsType {
+                depth: 1,
+                search_moves: vec![Move::WIN],
+                ..Default::default()
+            },
+            None::<fn(&SearchInfo)>,
+        );
+        assert_eq!(result.best_move, Move::NONE);
+        assert_eq!(result.score, Value::ZERO);
+    });
+}
+
+#[test]
+fn aspiration_abort_returns_completed_result() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        let mut pos = Position::new();
+        pos.set_hirate();
+        for usi in ["7g7f", "3c3d", "2g2f", "8c8d", "2f2e", "8d8e"] {
+            let mv = pos.to_move(Move::from_usi(usi).unwrap()).unwrap();
+            assert!(RootMoves::from_legal_moves(&pos, &[]).find(mv).is_some());
+            let check = pos.gives_check(mv);
+            pos.do_move(mv, check);
+        }
+        let mut search = Search::new(1);
+        let mut infos = Vec::new();
+        let result = search.go(
+            &mut pos,
+            LimitsType {
+                nodes: 13_678,
+                ..Default::default()
+            },
+            Some(|info: &SearchInfo| infos.push(info.clone())),
+        );
+        // 最終infoは返値から再生成されるため、その直前の完了infoと比較する。
+        let completed = &infos[infos.len() - 2];
+        assert_eq!(result.depth, 10);
+        assert_eq!(result.best_move.to_usi(), "2h6h");
+        assert_eq!(result.score, Value::ZERO);
+        assert_eq!(result.depth, completed.depth);
+        assert_eq!(result.best_move, completed.pv[0]);
+        assert_eq!(result.score, completed.score);
+        assert_eq!(infos.last().unwrap().pv, completed.pv);
+        assert_eq!(result.ponder_move, completed.pv.get(1).copied().unwrap_or(Move::NONE));
+    });
+}
+
+#[test]
+fn aspiration_abort_multipv_and_helpers_keep_valid_results() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        for threads in [1, 2] {
+            for multi_pv in [1, 4] {
+                let mut pos = Position::new();
+                pos.set_hirate();
+                let mut search = Search::new(1);
+                search.set_num_threads(threads);
+                let mut infos = Vec::new();
+                let result = search.go(
+                    &mut pos,
+                    LimitsType {
+                        nodes: 8_000,
+                        multi_pv,
+                        ..Default::default()
+                    },
+                    Some(|info: &SearchInfo| infos.push(info.clone())),
+                );
+                assert!(result.depth > 0);
+                assert!(result.score.raw().abs() < Value::INFINITE.raw());
+                let final_info = infos.last().unwrap();
+                assert_eq!(result.best_move, final_info.pv[0]);
+                assert_eq!(result.score, final_info.score);
+                assert_eq!(result.depth, final_info.depth);
+                if threads == 1 {
+                    let completed = infos[..infos.len() - 1]
+                        .iter()
+                        .rev()
+                        .find(|info| info.multi_pv == 1)
+                        .unwrap();
+                    assert_eq!(result.depth, completed.depth);
+                    assert_eq!(result.score, completed.score);
+                    assert_eq!(final_info.pv, completed.pv);
+                }
+                for &mv in &final_info.pv {
+                    assert!(RootMoves::from_legal_moves(&pos, &[]).find(mv).is_some());
+                    let check = pos.gives_check(mv);
+                    pos.do_move(mv, check);
+                }
+            }
+        }
+    });
+}

--- a/crates/rshogi-core/src/search/tests/terminal_result.rs
+++ b/crates/rshogi-core/src/search/tests/terminal_result.rs
@@ -153,7 +153,10 @@ fn aspiration_abort_multipv_and_helpers_keep_valid_results() {
                     assert_eq!(result.score, completed.score);
                     assert_eq!(final_info.pv, completed.pv);
                 }
-                for &mv in &final_info.pv {
+                // SMP の既存の PV 生成不整合とは分離し、返却手の合法性を検証する。
+                // 単一スレッドでは完了 PV の全手も再生する。
+                let replay_len = if threads == 1 { final_info.pv.len() } else { 1 };
+                for &mv in final_info.pv.iter().take(replay_len) {
                     assert!(RootMoves::from_legal_moves(&pos, &[]).find(mv).is_some());
                     let check = pos.gives_check(mv);
                     pos.do_move(mv, check);

--- a/crates/rshogi-core/src/search/types.rs
+++ b/crates/rshogi-core/src/search/types.rs
@@ -590,6 +590,19 @@ pub struct RootMoves {
     moves: Vec<RootMove>,
 }
 
+impl Clone for RootMoves {
+    fn clone(&self) -> Self {
+        Self {
+            moves: self.moves.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        // 反復ごとの退避では既存バッファを再利用する。
+        self.moves.clone_from(&source.moves);
+    }
+}
+
 impl RootMoves {
     /// 空のRootMovesを作成
     pub fn new() -> Self {


### PR DESCRIPTION
非王手で合法手がない局面を敗北評価にし、探索中断時には最後に完了した反復の指し手・評価値・PVを一貫して返すようにします。これにより、完了深さの指し手に探索途中の番兵値（-32001）が組み合わされる問題を防ぎます。

完了時にRootMoves全体を保存し、MultiPV・skill・helperの結果選択より前に復元します。searchmovesによる候補ゼロ、excluded move、qsearchの評価契約は維持します。

検証:
- 非王手の合法手ゼロ、searchmovesによる候補ゼロ、中断後の評価値・PV・ponderの整合性を回帰テストで確認。
- SMP/MultiPVを含む回帰テスト、fmt、Clippy、全体テスト、CIを確認。

深さ1完了前の未初期化評価値の扱いと、既存の不正PV生成は対象外です。公開PVの検証は後続の#1082で対応します。

固定深さのNNUE比較では探索結果・ノード数の一致を確認済みです。固定時間の性能評価は未確定です。
