### PR TITLE
fix(search): 兄弟ノードの読み筋が PV に混ざらないよう子の行を維持する

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2360,6 +2360,14 @@ impl SearchWorker {
             };
         }
 
+        // 親の PvTable::update はこの ply の行をそのままコピーする。千日手・中断・
+        // Mate Distance Pruning 等の早期 return でも兄弟ノードの行を渡さないよう、
+        // それらより前に空にする (YaneuraOu / Stockfish が親側で (ss+1)->pv を clear するのと同等)。
+        if pv_node {
+            st.pv_table.clear(ply as usize);
+            st.pv_table.clear((ply + 1) as usize);
+        }
+
         let liveness_nodes = st.nodes;
         if let Some(liveness) = st.depth_liveness.as_mut() {
             let excluded_search = st.stack[ply as usize].excluded_move.is_some();
@@ -2438,14 +2446,6 @@ impl SearchWorker {
         // (ss+2)->cutoffCnt = 0（祖父ノードがリセット）
         // 兄弟ノード間で cutoff_cnt が蓄積されるように ply+2 を初期化する
         unsafe { st.stack.get_unchecked_mut((ply + 2) as usize) }.cutoff_cnt = 0;
-
-        // PVノードの場合、PVをクリアして前回探索の残留を防ぐ
-        // NOTE: YaneuraOuでは (ss+1)->pv = pv でポインタを新配列に向け、ss->pv[0] = Move::none() でクリア
-        //       Vecベースの実装では明示的なclear()で同等の効果を得る
-        if pv_node {
-            st.pv_table.clear(ply as usize);
-            st.pv_table.clear((ply + 1) as usize);
-        }
 
         let prior_reduction = take_prior_reduction(st, ply);
         // SAFETY: ply < MAX_PLY < STACK_SIZE。
@@ -2800,6 +2800,11 @@ impl SearchWorker {
 
             move_count += 1;
             st.stack[ply as usize].move_count = move_count;
+            // NonPV で探索した手が同点昇格等で best_move になったときに、前の兄弟の行を
+            // 子の続きとしてコピーしないよう、手ごとに子の行を空にしておく。
+            if pv_node {
+                st.pv_table.clear((ply + 1) as usize);
+            }
 
             let is_capture = pos.is_capture(mv);
             let gives_check = pos.gives_check(mv);

--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -56,6 +56,13 @@ pub(super) fn qsearch<const NT: u8>(
         };
     }
 
+    // 親の PvTable::update はこの ply の行をそのままコピーするため、早期 return でも
+    // 兄弟ノードが残した行を渡さないよう、PV ノードでは最初に空にしてから自前で維持する。
+    if pv_node {
+        st.pv_table.clear(ply as usize);
+        st.pv_table.clear((ply + 1) as usize);
+    }
+
     if pv_node && st.sel_depth < ply + 1 {
         st.sel_depth = ply + 1;
     }
@@ -493,6 +500,9 @@ pub(super) fn qsearch<const NT: u8>(
             if value > alpha {
                 // value > alpha のときのみ bestMove を更新
                 best_move = mv;
+                if pv_node {
+                    st.pv_table.update(ply as usize, mv);
+                }
 
                 if value >= beta {
                     break;

--- a/crates/rshogi-core/src/search/tests/mod.rs
+++ b/crates/rshogi-core/src/search/tests/mod.rs
@@ -13,3 +13,4 @@ mod mate1_tt;
 mod probcut_abort;
 
 mod terminal_result;
+mod pv_legality;

--- a/crates/rshogi-core/src/search/tests/mod.rs
+++ b/crates/rshogi-core/src/search/tests/mod.rs
@@ -12,5 +12,5 @@ mod time_management;
 mod mate1_tt;
 mod probcut_abort;
 
-mod terminal_result;
 mod pv_legality;
+mod terminal_result;

--- a/crates/rshogi-core/src/search/tests/pv_legality.rs
+++ b/crates/rshogi-core/src/search/tests/pv_legality.rs
@@ -1,0 +1,161 @@
+//! 探索が報告する PV の合法性テスト
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use crate::eval::EvalHash;
+use crate::movegen::is_legal_with_pass;
+use crate::position::Position;
+use crate::search::alpha_beta::SearchWorker;
+use crate::search::engine::{Search, SearchInfo};
+use crate::search::{LimitsType, NodeType, SearchTuneParams, TimeManagement};
+use crate::tt::TranspositionTable;
+use crate::types::{Move, Value};
+
+const ROOTS: [&str; 5] = [
+    "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+    "lnsgkgsnl/1r7/p1ppp1bpp/1p3pp2/7P1/2P6/PP1PPPP1P/1B3S1R1/LNSGKG1NL b - 9",
+    "l4S2l/4g1gs1/5p1p1/pr2N1pkp/4Gn3/PP3PPPP/2GPP4/1K7/L3r+s2L w BS2N5Pb 1",
+    "6n1l/2+S1k4/2lp4p/1np1B2b1/3PP4/1N1S3rP/1P2+pPP+p1/1p1G5/3KG2r1 b GSN2L4Pgs2p 1",
+    "l6nl/5+P1gk/2np1S3/p1p4Pp/3P2Sp1/1PPb2P1P/P5GS1/R8/LN4bKL w RGgsn5p 1",
+];
+const DEPTH: i32 = 10;
+
+fn on_large_stack(f: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(f)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+fn assert_legal_line(root_sfen: &str, pv: &[Move], context: &str) {
+    let mut pos = Position::new();
+    pos.set_sfen(root_sfen).unwrap();
+    for &mv in pv {
+        let legal = mv != Move::NONE
+            && (mv.is_pass() || pos.pseudo_legal(mv))
+            && is_legal_with_pass(&pos, mv);
+        assert!(
+            legal,
+            "{context}: {} は不正な手。pv={:?}",
+            mv.to_usi(),
+            pv.iter().map(|m| m.to_usi()).collect::<Vec<_>>()
+        );
+        let check = pos.gives_check(mv);
+        pos.do_move(mv, check);
+    }
+}
+
+/// 兄弟ノードの読み筋が子の続きとして親へ渡ると、途中で不正になる PV が報告される。
+#[test]
+fn every_reported_pv_is_legal() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        for root_sfen in ROOTS {
+            for multi_pv in [1, 4] {
+                let mut search = Search::new(16);
+                let mut pos = Position::new();
+                pos.set_sfen(root_sfen).unwrap();
+                let limits = LimitsType {
+                    depth: DEPTH,
+                    multi_pv,
+                    ..Default::default()
+                };
+                let mut infos = Vec::new();
+                let result =
+                    search.go(&mut pos, limits, Some(|info: &SearchInfo| infos.push(info.clone())));
+                let case = format!("sfen={root_sfen} multi_pv={multi_pv}");
+
+                assert_eq!(result.depth, DEPTH, "{case}");
+                assert!(!result.pv.is_empty(), "{case}");
+                assert_eq!(result.pv[0], result.best_move, "{case}");
+                assert_legal_line(root_sfen, &result.pv, &format!("{case} result"));
+
+                let final_lines: BTreeSet<usize> = infos
+                    .iter()
+                    .filter(|info| info.depth == DEPTH)
+                    .map(|info| info.multi_pv)
+                    .collect();
+                assert_eq!(final_lines, (1..=multi_pv).collect(), "{case}");
+
+                for info in &infos {
+                    let context = format!("{case} depth={} line={}", info.depth, info.multi_pv);
+                    assert!(!info.pv.is_empty(), "{context}");
+                    assert_legal_line(root_sfen, &info.pv, &context);
+                }
+            }
+        }
+    });
+}
+
+/// ply 1 の行に兄弟ノードの手を仕込んでから PV ノードとして探索し、返った後のその行を返す。
+fn search_child_with_stale_row(sfen: &str, depth: i32, alpha: Value) -> Vec<Move> {
+    let limits = LimitsType {
+        depth: 1,
+        ..Default::default()
+    };
+    let mut worker = SearchWorker::new(
+        Arc::new(TranspositionTable::new(1)),
+        Arc::new(EvalHash::new(1)),
+        0,
+        0,
+        SearchTuneParams::default(),
+    );
+    worker.prepare_search(&limits);
+    let mut pos = Position::new();
+    pos.set_sfen(sfen).unwrap();
+    let ply = 1;
+    worker.state.pv_table.update(ply as usize, Move::from_usi("3a2b").unwrap());
+    let mut tm =
+        TimeManagement::new(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
+    worker.search_node_wrapper::<{ NodeType::PV as u8 }>(
+        &mut pos,
+        depth,
+        alpha,
+        Value::INFINITE,
+        ply,
+        false,
+        &limits,
+        &mut tm,
+    );
+    worker.state.pv_table.line(ply as usize).to_vec()
+}
+
+#[test]
+fn pv_node_early_return_drops_sibling_line() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        // ply 1 で alpha >= mate_in(2) なら Mate Distance Pruning で即 return する。
+        let line = search_child_with_stale_row(ROOTS[0], 4, Value::mate_in(2));
+        assert!(line.is_empty(), "{line:?}");
+    });
+}
+
+#[test]
+fn qsearch_pv_node_drops_sibling_line() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        // 平手は駒を取る手が無いので、qsearch は手を選ばずに返る。
+        let line = search_child_with_stale_row(ROOTS[0], 0, -Value::INFINITE);
+        assert!(line.is_empty(), "{line:?}");
+    });
+}
+
+#[test]
+fn qsearch_pv_node_records_best_capture() {
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+    on_large_stack(|| {
+        // 取り返されない歩をただで取れる局面。qsearch はその捕獲手を自分の行に書く。
+        let line =
+            search_child_with_stale_row("4k4/9/9/9/4p4/4R4/9/9/4K4 b - 1", 0, -Value::INFINITE);
+        let line: Vec<_> = line.iter().map(|m| m.to_usi()).collect();
+        assert_eq!(line.first().map(String::as_str), Some("5f5e"), "{line:?}");
+    });
+}


### PR DESCRIPTION
## Summary

探索が報告する PV に、移動済みの駒を再び動かす等の不正な続きが混ざる問題の根本原因を修正します。単一スレッドの平手 depth 8 でも再現していました (例: `5i5h 2c2d 5h5i 1a1b 5i5h 4a5b 5h5i 4a5b`)。

`PvTable::update(ply, mv)` は子の行 (`ply + 1`) をそのまま `mv` の後ろにコピーします。次の 3 経路で前の兄弟ノードの行が残ったまま親へ渡っていました。

- qsearch が PV ノードでも自分の行を clear / update しない
- search_node の PV clear が千日手・中断・Mate Distance Pruning 等の早期 return の後にある
- PV ノードで NonPV 探索した手が同点昇格で best_move になると、兄弟の行を接続する

Stockfish / YaneuraOu と同じく、qsearch の PV ノードで入口 clear と `value > alpha` での update を行い、search_node の clear を早期 return より前へ移し、PV ノードの各手の探索前に子の行を clear します。

#1082 (公開 PV の合法接頭列への打ち切り) が「別件」としていた内部 PV 生成の原因にあたります。

## 探索への影響

`previous_pv` は `follow_pv` 経由で枝刈り判定に使われるため、探索木は変わります (YaneuraOu / Stockfish と同じ前提に戻る方向)。固定 depth 16 では 5 局面中 4 局面で nodes、2 局面で bestmove が変化しました。棋力は非劣性 SPRT で確認します (結果は下に追記)。

## 性能

探索木が一致する条件 (tactical 局面 depth 16、nodes 1,766,984 一致、production edition、本番 NNUE、`perf stat -r 10` abba):

| 指標 | baseline | candidate | 差 |
|---|---:|---:|---:|
| instructions | 26,854.4M | 26,859.1M | +0.017% |
| cycles | 14,793.9M | 14,775.9M | −0.12% (baseline 同士の揺れ 1.2% 内) |

追加処理は PV ノードでの行長リセットと qsearch の PV コピーのみで、ヒープ確保はありません。固定時間 A/B (search_only_ab) の局面別 cycles/node は −3.0〜+0.8% でしたが、探索木が異なるため実装コストの指標にはしていません。

## Test plan

- [x] `search::tests::pv_legality` 4 本 (5 局面 × MultiPV 1/4 の全 SearchInfo / SearchResult PV の合法性、早期 return と qsearch で兄弟の行が残らないこと、qsearch が最善の捕獲手を行に書くこと): 修正前 red 4/4、修正後 green 4/4
- [x] cargo fmt / clippy --tests / cargo test / tracked 絶対パス検査
- [x] ローカル Codex review: 初回 REQUEST_CHANGES (同点昇格経路) → 対応後 APPROVE
- [x] 非劣性 SPRT (byoyomi 1000 ms、nelo −10 / 0、α=β=0.05): **accept_h1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M36maxLzH884tBCQXZzMbb

## SPRT 結果 (非劣性)

baseline `6aed4c73` (main) vs candidate `c5a1e7cf`、同一 edition / production、本番 NNUE (nnue_ledger の production、FV_SCALE=14 / progresskpabs / buckets 9)、byoyomi 1000 ms、Threads 1、Hash 256 MB、startpos ply32、seed 20260912、concurrency 16。

- **accept_h1** (境界到達時点: 2,875 pair、LLR +2.972、bounds ±2.944、H0 −10 / H1 0、α=β=0.05)
- nelo **+0.78 ± 8.97** / elo +0.72 ± 8.31 (candidate 視点)、penta [569, 184, 1372, 182, 576]、5,766 局完了
- 記録: 停止後の drain を含む最終値は LLR +2.760 で境界の内側に戻り、post-hoc の `analyze_selfplay --sprt` は未完了ペア 1 件を除外するため部分集計扱いになる。採否は事前登録どおり境界到達時点で確定。
- run 健全性: error / 再試行 / 枯渇ペア 0、invalid false、timed_out 0 (平均消費 928 ms / 上限 1000 ms)、共有重み marker は両 side 16 ログすべて shared (local 0)、max_moves 到達率 0.02% (1/5767)
