### PR TITLE
test(workers): 終局障害後のcron回収を実Workerで検証

### DIFF
--- a/crates/rshogi-csa-server-workers/tests/finalization_exhaustive/exhaustive-worker.mjs
+++ b/crates/rshogi-csa-server-workers/tests/finalization_exhaustive/exhaustive-worker.mjs
@@ -1,6 +1,15 @@
 import worker, { GameRoom as RustGameRoom, Lobby, RateLimiter } from '../../build/worker/shim.mjs';
 export { Lobby, RateLimiter };
-export default worker;
+// テスト専用入口から本物の scheduled ハンドラを実行する。
+// :15 を指定し、毎正時の backfill と切り離して sweep を検証する。
+export default class extends worker {
+  async fetch(request) {
+    if (new URL(request.url).pathname !== '/__test/cron') return super.fetch(request);
+    const scheduledTime = Math.floor(Date.now() / 3_600_000) * 3_600_000 + 15 * 60_000;
+    await this.scheduled({ cron: '*/15 * * * *', scheduledTime, noRetry() {} });
+    return new Response('ok');
+  }
+}
 
 const STORAGE_EFFECTS = ['get', 'put', 'delete', 'deleteMultiple', 'getAlarm', 'setAlarm', 'deleteAlarm'];
 const SOCKET_EFFECTS = ['send', 'serializeAttachment', 'close'];

--- a/crates/rshogi-csa-server-workers/tests/finalization_exhaustive/finalization_exhaustive.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/finalization_exhaustive/finalization_exhaustive.test.ts
@@ -69,6 +69,8 @@ interface Observation {
   kifuMoves: number | null;
   historyObjects: number;
   liveEntries: number;
+  /** 残存を観測した後、実 scheduled ハンドラによる回収を確認できた件数。 */
+  cronRecoveredEntries: number;
 }
 
 interface Finding {
@@ -111,12 +113,13 @@ const SCENARIOS: Scenario[] = [
 
 const MODES: Mode[] = ['fail', 'crash'];
 
-// KEY_FINISHED 確定後の live-games-index 削除漏れは cron sweep が回収する契約。
-const CRON_RECOVERED = 'live 一覧に残っている';
+// KEY_FINISHED 確定後の削除漏れは、実際に cron sweep で消えた場合だけ許容する。
+const CRON_RECOVERED = 'cron 実行で live 一覧から回収できた';
 const INPUT_LOST_OTHER_RESULT = '入力が失われ別の裁定で確定した';
 
-// `scenario/mode/at` を指定すると、その 1 ケースだけを実行して状態を出力する。
+// `scenario/mode/at` (複数ならカンマ区切り) を指定すると、対象だけを実行して状態を出力する。
 const ONLY_CASE = process.env.FINALIZATION_EXHAUSTIVE_CASE;
+const SELECTED_CASES = ONLY_CASE ? new Set(ONLY_CASE.split(',')) : null;
 
 describe('終局処理の網羅障害注入', () => {
   const servers = new Map<string, { mf: Miniflare; cleanup: () => Promise<void> }>();
@@ -134,6 +137,9 @@ describe('終局処理の網羅障害注入', () => {
     for (const { mf, cleanup } of servers.values()) {
       await mf.dispose();
       await cleanup();
+    }
+    if (SELECTED_CASES) {
+      expect(coverage.map(c => `${c.scenario}/${c.mode}/${c.at}`).sort()).toEqual([...SELECTED_CASES].sort());
     }
   });
 
@@ -266,6 +272,7 @@ describe('終局処理の網羅障害注入', () => {
       kifuMoves: kifuText === null ? null : kifuText.split('\n').filter(l => /^[+-]\d{4}/.test(l)).length,
       historyObjects: history.length,
       liveEntries: live.length,
+      cronRecoveredEntries: 0,
     };
   }
 
@@ -276,6 +283,36 @@ describe('終局処理の網羅障害注入', () => {
     await scenario.trigger(game);
     const state = await drive(game);
     const observation = await observe(mf, game, state);
+    if (observation.liveEntries > 0 && state.finished?.exported_at_ms != null) {
+      const kifu = await getKifuBucket(mf);
+      const history = await getFloodgateHistoryBucket(mf);
+      const savedObjects = async (bucket: typeof kifu, prefix: string) => {
+        const values: Record<string, string> = {};
+        let cursor: string | undefined;
+        do {
+          const page = await bucket.list({ prefix, cursor });
+          for (const { key } of page.objects) {
+            if (key.includes(game.gameId)) values[key] = await (await bucket.get(key))!.text();
+          }
+          cursor = page.truncated ? page.cursor : undefined;
+          if (page.truncated && !cursor) throw new Error('R2 list の cursor がない');
+        } while (cursor);
+        return values;
+      };
+      const beforeKifu = await savedObjects(kifu, 'kifu-by-id/');
+      const beforeHistory = await savedObjects(history, '');
+      expect(Object.keys(beforeKifu).some(key => key.endsWith('.csa'))).toBe(true);
+      expect(Object.keys(beforeKifu).some(key => key.endsWith('.meta.json'))).toBe(true);
+      // 2 回目も走らせ、回収後に再実行しても棋譜・履歴を壊さないことを確認する。
+      for (let sweep = 0; sweep < 2; sweep++) {
+        const response = await mf.dispatchFetch('https://example.com/__test/cron', { method: 'POST' });
+        expect(response.status).toBe(200);
+        expect(await savedObjects(kifu, 'live-games-index/')).toEqual({});
+        expect(await savedObjects(kifu, 'kifu-by-id/')).toEqual(beforeKifu);
+        expect(await savedObjects(history, '')).toEqual(beforeHistory);
+      }
+      observation.cronRecoveredEntries = observation.liveEntries;
+    }
     await game.black.close();
     await game.white.close();
     game.spectator?.close();
@@ -318,7 +355,10 @@ describe('終局処理の網羅障害注入', () => {
     }
     if (observed.kifuMoves !== baseline.kifuMoves) problems.push(`棋譜の手数が違う: ${observed.kifuMoves}`);
     if (observed.historyObjects !== baseline.historyObjects) problems.push(`floodgate 履歴が ${observed.historyObjects} 件`);
-    if (observed.liveEntries !== 0) problems.push(CRON_RECOVERED);
+    if (observed.liveEntries !== 0) {
+      problems.push(observed.cronRecoveredEntries === observed.liveEntries
+        ? CRON_RECOVERED : 'cron 実行後も live 一覧に残っている');
+    }
     for (const watcher of Object.keys(baseline.lines) as Watcher[]) {
       const got = observed.lines[watcher] ?? [];
       const want = baseline.lines[watcher] ?? [];
@@ -344,7 +384,7 @@ describe('終局処理の網羅障害注入', () => {
         expect(baseline.historyObjects).toBe(1);
         const total = baseline.state.ops.length;
         for (let at = 1; at <= total; at++) {
-          if (ONLY_CASE && ONLY_CASE !== `${scenario.name}/${mode}/${at}`) continue;
+          if (SELECTED_CASES && !SELECTED_CASES.has(`${scenario.name}/${mode}/${at}`)) continue;
           const observed = await runCase(scenario, { at, mode });
           const op = observed.state.injectedAt?.name ?? `(未到達) ${baseline.state.ops[at - 1]}`;
           const problems = check(baseline, observed, scenario.disconnectedWatcher);

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/cron_recovery.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/cron_recovery.test.ts
@@ -1,0 +1,40 @@
+import { resolve } from 'node:path';
+import { expect, it } from 'vitest';
+import { createMiniflare, getKifuBucket, makeTempPersistRoot } from './harness.ts';
+
+it('cron は確定済みの一覧項目だけを回収し、未確定の対局と棋譜を保持する', async () => {
+  const persist = await makeTempPersistRoot();
+  const mf = await createMiniflare({
+    persistRoot: persist.path,
+    scriptPath: resolve(import.meta.dirname, '../finalization_exhaustive/exhaustive-worker.mjs'),
+  });
+  try {
+    const writer = await mf.getR2Bucket('KIFU_BUCKET') as unknown as {
+      put(key: string, value: string): Promise<unknown>;
+    };
+    const bucket = await getKifuBucket(mf);
+    const started = Date.now();
+    const entries = ['finished', 'active', 'csa-without-meta'];
+    const liveKey = (id: string) => `live-games-index/000-${id}.json`;
+    const body = (id: string) => JSON.stringify({ game_id: id, started_at_ms: started });
+    for (const id of entries) await writer.put(liveKey(id), body(id));
+    const metaKey = 'kifu-by-id/finished.meta.json';
+    await writer.put(metaKey, '{}');
+    const csaKeys = ['kifu-by-id/finished.csa', 'kifu-by-id/csa-without-meta.csa'];
+    for (const key of csaKeys) await writer.put(key, 'V2.2\n%TORYO\n');
+
+    for (let sweep = 0; sweep < 2; sweep++) {
+      const response = await mf.dispatchFetch('https://example.com/__test/cron', { method: 'POST' });
+      expect(response.status).toBe(200);
+      expect(await bucket.get(liveKey('finished'))).toBeNull();
+      for (const id of ['active', 'csa-without-meta']) {
+        expect(await (await bucket.get(liveKey(id)))?.text()).toBe(body(id));
+      }
+      expect(await (await bucket.get(metaKey))?.text()).toBe('{}');
+      for (const key of csaKeys) expect(await (await bucket.get(key))?.text()).toBe('V2.2\n%TORYO\n');
+    }
+  } finally {
+    await mf.dispose();
+    await persist.cleanup();
+  }
+});


### PR DESCRIPTION
#1078 の障害注入テストでは、終局済みの対局が live 一覧に残る場合を、cron の回収対象として分類するだけでした。テスト専用入口から実 Worker の scheduled ハンドラを実行し、一覧からの削除と棋譜・終了メタデータ・floodgate 履歴の保持を確認できた場合だけ `cronRecovered` に記録します。2 回実行して再実行時の保持も検査します。

CI 用の smoke テストでは、確定済み項目の回収に加え、未確定の対局や CSA 本文だけが存在する対局を削除しないことを検査します。網羅テストのケース指定はカンマ区切りに対応し、指定した全ケースの実行を必須にしました。

検証は両 PR マージ後の main `c7cf44bc` を基準に、WSL / Miniflare / 再ビルドした Worker で実施しました。

- 以前の回収対象 30 ケースを指定して再現：30 点すべてに障害注入、30 件すべて回収、違反 0 件（174.97 秒）。今回は 780 点全体の再実行ではありません。
- Worker smoke：18 ファイル、91 件成功。
- 関連 2 crate の Rust テスト：703 件成功、失敗 0 件、ignore 2 件。
- fmt、Clippy、変更した TypeScript の strict 型検査、tracked absolute path 検査が成功。

本番コードの変更はありません。Cloudflare Staging の cron 配信・実行状況の確認、および裁定保存前の入力喪失の解消は対象外です。
